### PR TITLE
Feature/add basic auth to engine api

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,14 @@ This is the main component of the _secureCodeBox_ it's a [Camunda][camunda] [BPM
 # Configuration Options
 To configure the SCB engine specify the following environment variables:
 
-| Environment Variable                  | Description                        | Example Value               |
-| ------------------------------------- | ---------------------------------- | --------------------------- |
-| SECURECODEBOX_DEFAULT_TARGET_NAME     | Default target identifier          | BodgeIT Public Host         |
-| SECURECODEBOX_DEFAULT_TARGET_LOCATION | Default target hostname/ip address | bodgeit                     |
-| SECURECODEBOX_DEFAULT_TARGET_URI      | Default target URI/URL             | http://bodgeit:8080/bodgeit |
-| SECURECODEBOX_DEFAULT_CONTEXT         | Default business context           | BodgeIT                     |
+| Environment Variable                  | Description                           | Example Value               |
+| ------------------------------------- | ------------------------------------- | --------------------------- |
+| SECURECODEBOX_DEFAULT_TARGET_NAME     | Default target identifier             | BodgeIT Public Host         |
+| SECURECODEBOX_DEFAULT_TARGET_LOCATION | Default target hostname/ip address    | bodgeit                     |
+| SECURECODEBOX_DEFAULT_TARGET_URI      | Default target URI/URL                | http://bodgeit:8080/bodgeit |
+| SECURECODEBOX_DEFAULT_CONTEXT         | Default business context              | BodgeIT                     |
+| SECURECODEBOX_USER_SCANNER            | Default user for scanner services     | default-scanner             |
+| SECURECODEBOX_USER_SCANNER_PW         | Default password for scanner services | AStrongPassword-NotThisOne! |
 
 # Development
 

--- a/pom.xml
+++ b/pom.xml
@@ -155,6 +155,12 @@
             </dependency>
 
             <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-starter-security</artifactId>
+                <version>${spring-boot.version}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>io.securecodebox.core</groupId>
                 <artifactId>sdk</artifactId>
                 <version>${project.parent.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,11 @@
                 <artifactId>camunda-bpm-spring-boot-starter-rest</artifactId>
                 <version>${camunda.spring.boot.starter.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-starter-security</artifactId>
+                <version>${spring-boot.version}</version>
+            </dependency>
 
             <dependency>
                 <groupId>org.camunda.bpm.springboot</groupId>
@@ -154,11 +159,6 @@
                 <version>${swagger-version}</version>
             </dependency>
 
-            <dependency>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-starter-security</artifactId>
-                <version>${spring-boot.version}</version>
-            </dependency>
 
             <dependency>
                 <groupId>io.securecodebox.core</groupId>

--- a/scb-engine/pom.xml
+++ b/scb-engine/pom.xml
@@ -182,6 +182,15 @@
             </dependencies>
         </profile>
         <profile>
+            <id>test</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <properties>
+                <activatedProfiles>test</activatedProfiles>
+            </properties>
+        </profile>
+        <profile>
             <id>docs</id>
             <activation>
                 <activeByDefault>false</activeByDefault>

--- a/scb-engine/pom.xml
+++ b/scb-engine/pom.xml
@@ -42,6 +42,10 @@
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger-ui</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
 
         <!-- Camunda Spin lib -->
         <dependency>

--- a/scb-engine/src/main/java/io/securecodebox/engine/auth/BasicAuthAuthProviderWebSecurityConfig.java
+++ b/scb-engine/src/main/java/io/securecodebox/engine/auth/BasicAuthAuthProviderWebSecurityConfig.java
@@ -1,0 +1,30 @@
+package io.securecodebox.engine.auth;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+
+
+@Configuration
+@EnableWebSecurity
+public class BasicAuthAuthProviderWebSecurityConfig extends WebSecurityConfigurerAdapter {
+
+
+    @Autowired
+    CamundaAuthenticationProvider camundaAuthenticationProvider;
+
+    @Override
+    protected void configure(final HttpSecurity http) throws Exception {
+        http.antMatcher("/box/**").authorizeRequests()
+            .anyRequest().authenticated()
+            .and().httpBasic();
+    }
+
+    @Autowired
+    public void configureGlobal(final AuthenticationManagerBuilder auth) throws Exception {
+        auth.authenticationProvider(camundaAuthenticationProvider);
+    }
+}

--- a/scb-engine/src/main/java/io/securecodebox/engine/auth/BasicAuthWebSecurityConfig.java
+++ b/scb-engine/src/main/java/io/securecodebox/engine/auth/BasicAuthWebSecurityConfig.java
@@ -1,6 +1,7 @@
 package io.securecodebox.engine.auth;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -10,17 +11,20 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 
 @Configuration
 @EnableWebSecurity
-public class BasicAuthAuthProviderWebSecurityConfig extends WebSecurityConfigurerAdapter {
+@ConditionalOnProperty(name = "securecodebox.rest.auth", havingValue = "basic auth")
+public class BasicAuthWebSecurityConfig extends WebSecurityConfigurerAdapter {
 
+    private static final String SCB_REST_API_URL = "/box";
 
     @Autowired
     CamundaAuthenticationProvider camundaAuthenticationProvider;
 
     @Override
     protected void configure(final HttpSecurity http) throws Exception {
-        http.antMatcher("/box/**").authorizeRequests()
+        http.antMatcher(SCB_REST_API_URL + "/**").authorizeRequests()
             .anyRequest().authenticated()
             .and().httpBasic();
+        http.csrf().disable();
     }
 
     @Autowired

--- a/scb-engine/src/main/java/io/securecodebox/engine/auth/CamundaAuthenticationProvider.java
+++ b/scb-engine/src/main/java/io/securecodebox/engine/auth/CamundaAuthenticationProvider.java
@@ -1,0 +1,38 @@
+package io.securecodebox.engine.auth;
+
+import java.util.Collections;
+import org.camunda.bpm.engine.ProcessEngine;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CamundaAuthenticationProvider implements AuthenticationProvider {
+
+    @Autowired
+    ProcessEngine engine;
+
+    @Override
+    public Authentication authenticate(Authentication auth) throws AuthenticationException {
+        String username = auth.getName();
+        String password = auth.getCredentials().toString();
+
+
+        boolean authenticated = engine.getIdentityService().checkPassword(username,password);
+
+        if (authenticated) {
+            return new UsernamePasswordAuthenticationToken(username, password, Collections.emptyList());
+        } else {
+            throw new BadCredentialsException("Authentication failed");
+        }
+    }
+
+    @Override
+    public boolean supports(Class<?> auth) {
+        return auth.equals(UsernamePasswordAuthenticationToken.class);
+    }
+}

--- a/scb-engine/src/main/java/io/securecodebox/engine/auth/NoAuthWebSecurityConfig.java
+++ b/scb-engine/src/main/java/io/securecodebox/engine/auth/NoAuthWebSecurityConfig.java
@@ -1,0 +1,22 @@
+package io.securecodebox.engine.auth;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+
+
+@Configuration
+@EnableWebSecurity
+@ConditionalOnProperty(name = "securecodebox.rest.auth", havingValue = "none")
+public class NoAuthWebSecurityConfig extends WebSecurityConfigurerAdapter {
+
+    @Override
+    protected void configure(final HttpSecurity http) throws Exception {
+        http.authorizeRequests()
+            .anyRequest().permitAll()
+            .and().httpBasic().disable();
+        http.csrf().disable();
+    }
+}

--- a/scb-engine/src/main/java/io/securecodebox/engine/helper/DefaultGroupConfiguration.java
+++ b/scb-engine/src/main/java/io/securecodebox/engine/helper/DefaultGroupConfiguration.java
@@ -28,6 +28,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Configuration;
 
+
 /**
  * This configuration file generates the default group approver and
  *
@@ -37,15 +38,17 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class DefaultGroupConfiguration extends AbstractCamundaConfiguration {
 
+    public static final String GROUP_SCANNER = "scanner";
+    public static final String GROUP_APPROVER = "approver";
+
     private static final Logger LOG = LoggerFactory.getLogger(DefaultGroupConfiguration.class);
 
     @Override
     public void postProcessEngineBuild(final ProcessEngine processEngine) {
 
         final IdentityService identityService = processEngine.getIdentityService();
-        createGroup(identityService, "approver");
-        createGroup(identityService, "scanner");
-
+        createGroup(identityService, GROUP_APPROVER);
+        createGroup(identityService, GROUP_SCANNER);
     }
 
     private void createGroup(IdentityService identityService, String group) {
@@ -58,4 +61,5 @@ public class DefaultGroupConfiguration extends AbstractCamundaConfiguration {
             LOG.info("Created default secureCodeBox group: {}", approverGroup.getName());
         }
     }
+
 }

--- a/scb-engine/src/main/java/io/securecodebox/engine/helper/DefaultUserConfiguration.java
+++ b/scb-engine/src/main/java/io/securecodebox/engine/helper/DefaultUserConfiguration.java
@@ -1,0 +1,84 @@
+/*
+ *
+ *  SecureCodeBox (SCB)
+ *  Copyright 2015-2018 iteratec GmbH
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ * /
+ */
+
+package io.securecodebox.engine.helper;
+
+import org.camunda.bpm.engine.AuthorizationService;
+import org.camunda.bpm.engine.IdentityService;
+import org.camunda.bpm.engine.ProcessEngine;
+import org.camunda.bpm.engine.identity.User;
+import org.camunda.bpm.spring.boot.starter.configuration.impl.AbstractCamundaConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * This configuration file adds a default user for scanner services
+ */
+@Configuration
+public class DefaultUserConfiguration extends AbstractCamundaConfiguration {
+
+    @Autowired
+    private PropertyValueProvider properties;
+
+    private static final Logger LOG = LoggerFactory.getLogger(DefaultUserConfiguration.class);
+
+    @Override
+    public void postProcessEngineBuild(final ProcessEngine processEngine) {
+        final IdentityService identityService = processEngine.getIdentityService();
+
+        if(identityService.isReadOnly()) {
+            LOG.warn("Identity service provider is Read Only, not creating any users.");
+            return;
+        }
+
+        setupTechnicalUserForScanner(identityService);
+    }
+
+    private void setupTechnicalUserForScanner(final IdentityService identityService) {
+        final String scannerUserId = properties.getDefaultUserScannerId();
+        final String scannerUserPw = properties.getDefaultUserScannerPassword();
+
+        if(scannerUserId == null || scannerUserId.isEmpty() || scannerUserPw == null || scannerUserPw.isEmpty()) {
+            LOG.info("No environment variables provided to create technical user for scanners");
+            return;
+        }
+
+        boolean userForScannersAlreadyExists = identityService.createUserQuery().userId(scannerUserId).count() > 0;
+        if(userForScannersAlreadyExists){
+            LOG.info("Technical user for scanners already exists");
+        } else {
+            LOG.info("Creating technical user for scanners");
+            createTechnicalUserForScanner(identityService, scannerUserId, scannerUserPw);
+            identityService.createMembership(scannerUserId, DefaultGroupConfiguration.GROUP_SCANNER);
+        }
+    }
+
+    private void createTechnicalUserForScanner(final IdentityService identityService, final String scannerUserId, final String scannerUserPw) {
+        User technicalUserForScanner = identityService.newUser(scannerUserId);
+        technicalUserForScanner.setPassword(scannerUserPw);
+        technicalUserForScanner.setFirstName("Technical-User");
+        technicalUserForScanner.setLastName("Default-Scanner");
+
+        identityService.saveUser(technicalUserForScanner);
+    }
+
+
+}

--- a/scb-engine/src/main/java/io/securecodebox/engine/helper/PropertyValueProvider.java
+++ b/scb-engine/src/main/java/io/securecodebox/engine/helper/PropertyValueProvider.java
@@ -29,6 +29,13 @@ public class PropertyValueProvider {
     @Value("${securecodebox.default.target.location}")
     private String defaultTargetLocation;
 
+    @Value("${securecodebox.rest.user.scanner-default.user-id}")
+    private String defaultUserScannerId;
+
+    @Value("${securecodebox.rest.user.scanner-default.password}")
+    private String defaultUserScannerPassword;
+
+
     /**
      * Default target access URI
      */
@@ -49,5 +56,13 @@ public class PropertyValueProvider {
 
     public String getDefaultTargetUri() {
         return defaultTargetUri;
+    }
+
+    String getDefaultUserScannerId() {
+        return defaultUserScannerId;
+    }
+
+    String getDefaultUserScannerPassword() {
+        return defaultUserScannerPassword;
     }
 }

--- a/scb-engine/src/main/resources/application-dev.yaml
+++ b/scb-engine/src/main/resources/application-dev.yaml
@@ -10,3 +10,7 @@ logging.level.io.securecodebox: TRACE
 # - none
 # - elasticsearch
 securecodebox.persistence.provider: none
+
+securecodebox.rest.user.scanner-default:
+  user-id: default-scanner
+  password: scan

--- a/scb-engine/src/main/resources/application.yaml
+++ b/scb-engine/src/main/resources/application.yaml
@@ -25,3 +25,8 @@ securecodebox.default.target.name: BodgeIT Public Host
 securecodebox.default.target.location: bodgeit
 securecodebox.default.target.uri: http://bodgeit:8080/bodgeit
 securecodebox.default.context: BodgeIT
+
+# Configure Secure CodeBox rest api protection
+# - basic auth
+# - none
+securecodebox.rest.auth: basic auth

--- a/scb-engine/src/main/resources/application.yaml
+++ b/scb-engine/src/main/resources/application.yaml
@@ -4,8 +4,8 @@
 spring.profiles.active: ${activatedProfiles}
 
 camunda.bpm:
-  webapp:
-    index-redirect-enabled: true
+  webapp.index-redirect-enabled: true
+  authorization.enabled: true
 
 logging.level: INFO
 logging.level.io.securecodebox: INFO

--- a/scb-engine/src/main/resources/application.yaml
+++ b/scb-engine/src/main/resources/application.yaml
@@ -30,3 +30,9 @@ securecodebox.default.context: BodgeIT
 # - basic auth
 # - none
 securecodebox.rest.auth: basic auth
+
+# Configure a technical user for the scanner services. This user allows the scanner services to authenticate on the engines rest api.
+# (if not configured, a user has to be added manually in the camunda ui)
+securecodebox.rest.user.scanner-default:
+  user-id:
+  password:

--- a/scb-engine/src/main/resources/application.yaml
+++ b/scb-engine/src/main/resources/application.yaml
@@ -32,7 +32,7 @@ securecodebox.default.context: BodgeIT
 securecodebox.rest.auth: basic auth
 
 # Configure a technical user for the scanner services. This user allows the scanner services to authenticate on the engines rest api.
-# (if not configured, a user has to be added manually in the camunda ui)
+# (If not set as environment variable, a user has to be added manually in the camunda ui.)
 securecodebox.rest.user.scanner-default:
-  user-id:
-  password:
+  user-id: ${SECURECODEBOX_USER_SCANNER:}
+  password: ${SECURECODEBOX_USER_SCANNER_PW:}

--- a/scb-engine/src/test/java/io/securecodebox/engine/auth/CamundaAuthenticationProviderTest.java
+++ b/scb-engine/src/test/java/io/securecodebox/engine/auth/CamundaAuthenticationProviderTest.java
@@ -1,0 +1,61 @@
+package io.securecodebox.engine.auth;
+
+import org.camunda.bpm.engine.IdentityService;
+import org.camunda.bpm.engine.ProcessEngine;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.Authentication;
+
+
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CamundaAuthenticationProviderTest {
+
+    @InjectMocks
+    CamundaAuthenticationProvider classUnderTest;
+
+    @Mock
+    ProcessEngine processEngine;
+
+    @Mock
+    IdentityService identityService;
+
+    @Mock
+    Authentication authDummy;
+
+    @Test
+    public void shouldAuthenticateIfCredentialsAreValid() {
+        given(authDummy.getName()).willReturn("username");
+        given(authDummy.getCredentials()).willReturn("correct-password");
+        given(processEngine.getIdentityService()).willReturn(identityService);
+        given(identityService.checkPassword("username","correct-password")).willReturn(true);
+
+        Authentication result = classUnderTest.authenticate(authDummy);
+
+        verify(identityService,times(1)).checkPassword("username","correct-password");
+        assertTrue(result.isAuthenticated());
+    }
+
+    @Test
+    public void shouldAuthenticateIfCredentialsAreInvalid() {
+        given(authDummy.getName()).willReturn("username");
+        given(authDummy.getCredentials()).willReturn("wrong-password");
+        given(processEngine.getIdentityService()).willReturn(identityService);
+        given(identityService.checkPassword("username","wrong-password")).willReturn(false);
+
+        final Throwable exception = catchThrowable(() -> classUnderTest.authenticate(authDummy));
+
+        verify(identityService,times(1)).checkPassword("username","wrong-password");
+        assertThat(exception).isInstanceOf(BadCredentialsException.class);
+    }
+}

--- a/scb-engine/src/test/resources/application.yml
+++ b/scb-engine/src/test/resources/application.yml
@@ -1,0 +1,5 @@
+spring.profiles.active: test
+
+securecodebox:
+  persistence.provider: none
+  rest.auth: none


### PR DESCRIPTION
- Added basic auth filter for scb rest api to authenticate against camunda identity service
- create technical camunda user on start for scanner services
- Enabled Camunda authorization via `camunda.bpm.authorization.enabled: true`