### PR TITLE
Feature/provide https support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ COPY --from=builder ./scb-persistenceproviders/elasticsearch-persistenceprovider
 
 WORKDIR /scb-engine
 
-COPY dockerfiles/init.sh ./init.sh
+COPY dockerfiles/init.sh .
 RUN chmod +x ./init.sh
 
 EXPOSE 8443
@@ -43,4 +43,4 @@ LABEL org.opencontainers.image.title="secureCodeBox Engine" \
     org.opencontainers.image.revision=$COMMIT_ID \
     org.opencontainers.image.created=$BUILD_DATE
 
-CMD [ "dockerfiles/init.sh" ]
+CMD ["./init.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,10 @@ COPY --from=builder ./scb-persistenceproviders/elasticsearch-persistenceprovider
 
 WORKDIR /scb-engine
 
-EXPOSE 8080
+COPY dockerfiles/init.sh ./init.sh
+RUN chmod +x ./init.sh
+
+EXPOSE 8443
 
 LABEL org.opencontainers.image.title="secureCodeBox Engine" \
     org.opencontainers.image.description="Orchestrating various security scans." \
@@ -40,4 +43,4 @@ LABEL org.opencontainers.image.title="secureCodeBox Engine" \
     org.opencontainers.image.revision=$COMMIT_ID \
     org.opencontainers.image.created=$BUILD_DATE
 
-ENTRYPOINT ["java", "-Dloader.path=./lib/,./plugins/", "-jar", "app.jar"]
+CMD [ "dockerfiles/init.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ WORKDIR /scb-engine
 COPY dockerfiles/init.sh .
 RUN chmod +x ./init.sh
 
+EXPOSE 8080
 EXPOSE 8443
 
 LABEL org.opencontainers.image.title="secureCodeBox Engine" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,4 +43,4 @@ LABEL org.opencontainers.image.title="secureCodeBox Engine" \
     org.opencontainers.image.revision=$COMMIT_ID \
     org.opencontainers.image.created=$BUILD_DATE
 
-CMD ["./init.sh"]
+ENTRYPOINT ["./init.sh"]

--- a/README.md
+++ b/README.md
@@ -26,6 +26,16 @@ To configure the SCB engine specify the following environment variables:
 | SECURECODEBOX_USER_SCANNER            | Default user for scanner services     | default-scanner             |
 | SECURECODEBOX_USER_SCANNER_PW         | Default password for scanner services | AStrongPassword-NotThisOne! |
 
+## Server Configuration
+Additionally all properties defined in scb-engine/src/main/resources/application.yaml can be overwritten via environment variables.
+This allows you to e.g. enable https using:
+
+| Environment Variable                  | Description                           | Example Value               |
+| ------------------------------------- | ------------------------------------- | --------------------------- |
+| SERVER_PORT                           | Defines the server port               | 8443                        |
+| SERVER_SSL_ENABLED                    | Enables http over ssl                 | true                        |
+| SERVER_SSL_KEY_STORE_PASSWORD         | Password to the java keystore         | AStrongPassword-NotThisOne! |
+
 # Development
 
 ## Local setup

--- a/dockerfiles/init.sh
+++ b/dockerfiles/init.sh
@@ -6,7 +6,7 @@ create_self_signed_certificate()
 {
     echo "Creating self signed certificate..."
     keytool -genkey -alias scb-engine -storetype PKCS12 -keyalg RSA -keysize 2048 -keystore keystore.p12 -validity 3650 \
-    -dname "CN=SecureCodeboxEngine, OU=SecureCodebox, O=SecureCodebox.io, C=DE, ST=HH, L=Hamburg" \
+    -dname "CN=secureCodeBoxEngine, OU=secureCodeBox.io, O=secureCodeBox.io, C=DE, ST=HH, L=Hamburg" \
     -storepass "${SERVER_SSL_KEY_STORE_PASSWORD}"
 }
 
@@ -23,14 +23,14 @@ create_certificate_if_not_available()
 }
 
 echo "Execute init script:"
-echo "Check if https is enabled"
+echo "Check if HTTPS is enabled..."
 if [ "${SERVER_SSL_ENABLED}" == "true" ]
 then 
     echo "Https enabled"
     create_certificate_if_not_available
 else
-    echo "No https enabled"
+    echo "No HTTPS enabled. You can use environment variables to enable HTTPS."
 fi
 
-echo "Starting scb engine..."
+echo "Starting secureCodeBox engine..."
 java -Dloader.path="./lib/,./plugins/" -jar ./app.jar

--- a/dockerfiles/init.sh
+++ b/dockerfiles/init.sh
@@ -1,11 +1,17 @@
-#!/bin/bash
+#!/bin/sh
 
 cd /scb-engine
 
-if [ ! -f keystore.p12 ]; then
+echo "Check if keystore already exists"
+if [ ! -f ./keystore.p12 ]
+then
+    echo "Keystore not found. Creating self signed certificate..."
     keytool -genkey -alias scb-engine -storetype PKCS12 -keyalg RSA -keysize 2048 -keystore keystore.p12 -validity 3650 \
     -dname "CN=SecureCodeboxEngine, OU=secure-codebox, O=SecureCodebox.io, C=DE, ST=HH, L=Hamburg" \
     -storepass "$ENGINE_KEYSTORE_PW"
+else
+    echo "Keystore already exists"
 fi
 
+echo "Starting scb engine..."
 java -Dloader.path="./lib/,./plugins/" -jar ./app.jar

--- a/dockerfiles/init.sh
+++ b/dockerfiles/init.sh
@@ -2,15 +2,34 @@
 
 cd /scb-engine
 
-echo "Check if keystore already exists"
-if [ ! -f ./keystore.p12 ]
-then
-    echo "Keystore not found. Creating self signed certificate..."
+create_self_signed_certificate()
+{
+    echo "Creating self signed certificate..."
     keytool -genkey -alias scb-engine -storetype PKCS12 -keyalg RSA -keysize 2048 -keystore keystore.p12 -validity 3650 \
-    -dname "CN=SecureCodeboxEngine, OU=secure-codebox, O=SecureCodebox.io, C=DE, ST=HH, L=Hamburg" \
-    -storepass "$ENGINE_KEYSTORE_PW"
+    -dname "CN=SecureCodeboxEngine, OU=SecureCodebox, O=SecureCodebox.io, C=DE, ST=HH, L=Hamburg" \
+    -storepass "${SERVER_SSL_KEY_STORE_PASSWORD}"
+}
+
+create_certificate_if_not_available()
+{
+    echo "Check if keystore already exists"
+    if [ ! -f ./keystore.p12 ]
+    then
+        echo "Keystore not found."
+        create_self_signed_certificate
+    else
+        echo "Keystore already exists"
+    fi
+}
+
+echo "Execute init script:"
+echo "Check if https is enabled"
+if [ "${SERVER_SSL_ENABLED}" == "true" ]
+then 
+    echo "Https enabled"
+    create_certificate_if_not_available
 else
-    echo "Keystore already exists"
+    echo "No https enabled"
 fi
 
 echo "Starting scb engine..."

--- a/dockerfiles/init.sh
+++ b/dockerfiles/init.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+cd /scb-engine
+
+if [ ! -f keystore.p12 ]; then
+    keytool -genkey -alias scb-engine -storetype PKCS12 -keyalg RSA -keysize 2048 -keystore keystore.p12 -validity 3650 \
+    -dname "CN=SecureCodeboxEngine, OU=secure-codebox, O=SecureCodebox.io, C=DE, ST=HH, L=Hamburg" \
+    -storepass "$ENGINE_KEYSTORE_PW"
+fi
+
+java -Dloader.path="./lib/,./plugins/" -jar ./app.jar

--- a/pom.xml
+++ b/pom.xml
@@ -160,7 +160,6 @@
                 <version>${swagger-version}</version>
             </dependency>
 
-
             <dependency>
                 <groupId>io.securecodebox.core</groupId>
                 <artifactId>sdk</artifactId>

--- a/scb-engine/src/main/java/io/securecodebox/engine/helper/DefaultUserConfiguration.java
+++ b/scb-engine/src/main/java/io/securecodebox/engine/helper/DefaultUserConfiguration.java
@@ -19,7 +19,6 @@
 
 package io.securecodebox.engine.helper;
 
-import org.camunda.bpm.engine.AuthorizationService;
 import org.camunda.bpm.engine.IdentityService;
 import org.camunda.bpm.engine.ProcessEngine;
 import org.camunda.bpm.engine.identity.User;

--- a/scb-engine/src/main/resources/application-dev.yaml
+++ b/scb-engine/src/main/resources/application-dev.yaml
@@ -1,3 +1,7 @@
+server:
+  port: 8080
+  ssl.enabled: false
+
 camunda.bpm:
   admin-user:
     id: kermit

--- a/scb-engine/src/main/resources/application-dev.yaml
+++ b/scb-engine/src/main/resources/application-dev.yaml
@@ -1,7 +1,3 @@
-server:
-  port: 8080
-  ssl.enabled: false
-
 camunda.bpm:
   admin-user:
     id: kermit

--- a/scb-engine/src/main/resources/application.yaml
+++ b/scb-engine/src/main/resources/application.yaml
@@ -3,12 +3,13 @@
 # mvn spring-boot:run -Pdev
 spring.profiles.active: ${activatedProfiles}
 
-server:
-  port: 8443
-  ssl:
-    enabled: true
+# Server configuration
+# These properties can be overwritten by environment variables to enable https
+server.port: 8080
+server.ssl:
+    enabled: false
+    key-store-password:
     key-store: keystore.p12
-    key-store-password: 123456
     key-store-type: PKCS12
     key-alias: scb-engine
 

--- a/scb-engine/src/main/resources/application.yaml
+++ b/scb-engine/src/main/resources/application.yaml
@@ -3,6 +3,15 @@
 # mvn spring-boot:run -Pdev
 spring.profiles.active: ${activatedProfiles}
 
+server:
+  port: 8443
+  ssl:
+    enabled: true
+    key-store: keystore.p12
+    key-store-password: 123456
+    key-store-type: PKCS12
+    key-alias: scb-engine
+
 camunda.bpm:
   webapp.index-redirect-enabled: true
   authorization.enabled: true


### PR DESCRIPTION
- added configuration properties and documentation to enable https
- addes script to create self signed certificate on first docker start
- it is possible to mount or copy a certificate into the container to use a real (not self signed) certificate