### PR TITLE
Add process_name variable when process is started via camunda ui

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ To run the testsuite run:
 
 ## Build
 
-To build the docker container run:
+To build the docker image run:
 
-`docker build -t CONTAINER_NAME .`
+`docker build -t IMAGE_NAME .`
 
 # Guidelines & Standards
 Well boring yes - but please read our [guidelines and naming standards][scb-developer-guidelines].

--- a/scb-engine/src/main/java/io/securecodebox/engine/execution/DefaultScanProcessExcecutionFactory.java
+++ b/scb-engine/src/main/java/io/securecodebox/engine/execution/DefaultScanProcessExcecutionFactory.java
@@ -18,9 +18,11 @@
  */
 package io.securecodebox.engine.execution;
 
+import io.securecodebox.constants.DefaultFields;
 import io.securecodebox.model.execution.ScanProcessExecution;
 import io.securecodebox.model.execution.ScanProcessExecutionFactory;
 import org.camunda.bpm.engine.delegate.DelegateExecution;
+import org.camunda.bpm.engine.repository.ProcessDefinition;
 import org.camunda.bpm.engine.variable.value.StringValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -61,12 +63,20 @@ public class DefaultScanProcessExcecutionFactory implements ScanProcessExecution
     private <P extends ScanProcessExecution> P getInstance(DelegateExecution execution, Class<P> customProcess) {
         try {
             execution.setVariable(PROCESS_EXECUTION_TYPE.name(), customProcess.getTypeName());
+            execution.setVariable(DefaultFields.PROCESS_NAME.name(), getProcessName(execution));
             LOG.debug("Writing {} to {}", PROCESS_EXECUTION_TYPE.name(), customProcess.getTypeName());
             return customProcess.getConstructor(DelegateExecution.class).newInstance(execution);
         } catch (InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
             LOG.error("Error creating custom process execution", e);
             throw new IllegalStateException("Error creating custom process execution", e);
         }
+    }
+
+    private String getProcessName(DelegateExecution execution) {
+        ProcessDefinition definition = execution.getProcessEngineServices().getRepositoryService().getProcessDefinition(execution.getProcessDefinitionId());
+        String processName = definition.getKey().replace("-process", "");
+        LOG.debug("Create DefaultScanProcessExecution for process " + processName);
+        return processName;
     }
 
     protected enum FactoryFields {


### PR DESCRIPTION
When a security test is started using the api, the "name" field is used to select the correct process and sets the security-test name.

When a security test is started using the camunda ui, the name field of a security test was never set. This Pull request should fix this.

I am not sure if the factory is the right place, but i didn't want to set the process variable in each camunda form for every process either.