### PR TITLE
Feature/restore original process target

### DIFF
--- a/scb-scanprocesses/combined-amass-nmap-process/src/main/java/io/securecodebox/scanprocesses/amassnmap/AdditionalProcessVariables.java
+++ b/scb-scanprocesses/combined-amass-nmap-process/src/main/java/io/securecodebox/scanprocesses/amassnmap/AdditionalProcessVariables.java
@@ -1,0 +1,24 @@
+/*
+ *
+ *  SecureCodeBox (SCB)
+ *  Copyright 2015-2018 iteratec GmbH
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ * /
+ */
+
+package io.securecodebox.scanprocesses.amassnmap;
+
+public enum AdditionalProcessVariables {
+    ORIGINAL_PROCESS_TARGET
+}

--- a/scb-scanprocesses/combined-amass-nmap-process/src/main/java/io/securecodebox/scanprocesses/amassnmap/OriginalTargetRestorer.java
+++ b/scb-scanprocesses/combined-amass-nmap-process/src/main/java/io/securecodebox/scanprocesses/amassnmap/OriginalTargetRestorer.java
@@ -1,0 +1,97 @@
+/*
+ *
+ *  SecureCodeBox (SCB)
+ *  Copyright 2015-2018 iteratec GmbH
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ * /
+ */
+
+package io.securecodebox.scanprocesses.amassnmap;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.securecodebox.constants.DefaultFields;
+import io.securecodebox.model.execution.Target;
+import io.securecodebox.model.findings.Finding;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.camunda.bpm.engine.delegate.DelegateExecution;
+import org.camunda.bpm.engine.delegate.JavaDelegate;
+import org.camunda.bpm.engine.variable.Variables;
+import org.camunda.bpm.engine.variable.value.ObjectValue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class OriginalTargetRestorer implements JavaDelegate {
+
+    private ObjectMapper objectMapper = new ObjectMapper();
+    private static final Logger LOG = LoggerFactory.getLogger(OriginalTargetRestorer.class);
+
+    @Override
+    public void execute(DelegateExecution execution) throws Exception {
+        LOG.debug("Starting to restore original target");
+        Target originalTarget = restoreOriginalTargetFromProcessVariable(execution);
+        storeTargetInProcessVariable(originalTarget, execution);
+        clearOriginalTargetProcessVariable(execution);
+        LOG.debug("Finished OriginalTargetRestorer service task.");
+    }
+
+
+    void storeOriginalTargetInSeparateProcessVariable(Target target, DelegateExecution execution){
+        try {
+            ObjectValue objectValue = Variables.objectValue(objectMapper.writeValueAsString(target))
+                    .serializationDataFormat(Variables.SerializationDataFormats.JSON)
+                    .create();
+            execution.setVariable(AdditionalProcessVariables.ORIGINAL_PROCESS_TARGET.name(), objectValue);
+        } catch (JsonProcessingException e) {
+            LOG.error("Could not store target in original-target process variable");
+        }
+    }
+
+    void clearOriginalTargetProcessVariable(DelegateExecution execution) {
+        execution.removeVariable(AdditionalProcessVariables.ORIGINAL_PROCESS_TARGET.name());
+    }
+
+    private Target restoreOriginalTargetFromProcessVariable(DelegateExecution execution) {
+        Target target = new Target();
+        try {
+            String originalTargetAsString = objectMapper.writeValueAsString(execution.getVariable(AdditionalProcessVariables.ORIGINAL_PROCESS_TARGET.name()));
+            target = objectMapper.readValue(originalTargetAsString, Target.class);
+        } catch (IOException e) {
+            LOG.error("Could not restore original target from process variable");
+        }
+        return target;
+    }
+
+    private void storeTargetInProcessVariable(Target target, DelegateExecution execution) {
+        try {
+            LOG.debug("Store target in process variable");
+
+            List<Target> newTargets = new ArrayList<>();
+            newTargets.add(target);
+
+            ObjectValue objectValue = Variables.objectValue(objectMapper.writeValueAsString(newTargets))
+                    .serializationDataFormat(Variables.SerializationDataFormats.JSON)
+                    .create();
+            execution.setVariable(DefaultFields.PROCESS_TARGETS.name(), objectValue);
+        } catch (IOException e) {
+            LOG.error("Could not store target in process variable");
+        }
+    }
+
+}

--- a/scb-scanprocesses/combined-amass-nmap-process/src/main/java/io/securecodebox/scanprocesses/amassnmap/OriginalTargetRestorer.java
+++ b/scb-scanprocesses/combined-amass-nmap-process/src/main/java/io/securecodebox/scanprocesses/amassnmap/OriginalTargetRestorer.java
@@ -19,11 +19,9 @@
 
 package io.securecodebox.scanprocesses.amassnmap;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.securecodebox.constants.DefaultFields;
 import io.securecodebox.model.execution.Target;
-import io.securecodebox.model.findings.Finding;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -33,7 +31,6 @@ import org.camunda.bpm.engine.variable.Variables;
 import org.camunda.bpm.engine.variable.value.ObjectValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -53,14 +50,7 @@ public class OriginalTargetRestorer implements JavaDelegate {
 
 
     void storeOriginalTargetInSeparateProcessVariable(Target target, DelegateExecution execution){
-        try {
-            ObjectValue objectValue = Variables.objectValue(objectMapper.writeValueAsString(target))
-                    .serializationDataFormat(Variables.SerializationDataFormats.JSON)
-                    .create();
-            execution.setVariable(AdditionalProcessVariables.ORIGINAL_PROCESS_TARGET.name(), objectValue);
-        } catch (JsonProcessingException e) {
-            LOG.error("Could not store target in original-target process variable");
-        }
+        execution.setVariable(AdditionalProcessVariables.ORIGINAL_PROCESS_TARGET.name(), target);
     }
 
     void clearOriginalTargetProcessVariable(DelegateExecution execution) {
@@ -68,13 +58,7 @@ public class OriginalTargetRestorer implements JavaDelegate {
     }
 
     private Target restoreOriginalTargetFromProcessVariable(DelegateExecution execution) {
-        Target target = new Target();
-        try {
-            String originalTargetAsString = objectMapper.writeValueAsString(execution.getVariable(AdditionalProcessVariables.ORIGINAL_PROCESS_TARGET.name()));
-            target = objectMapper.readValue(originalTargetAsString, Target.class);
-        } catch (IOException e) {
-            LOG.error("Could not restore original target from process variable");
-        }
+        Target target = (Target) execution.getVariable(AdditionalProcessVariables.ORIGINAL_PROCESS_TARGET.name());
         return target;
     }
 

--- a/scb-scanprocesses/combined-amass-nmap-process/src/main/java/io/securecodebox/scanprocesses/amassnmap/OriginalTargetRestorer.java
+++ b/scb-scanprocesses/combined-amass-nmap-process/src/main/java/io/securecodebox/scanprocesses/amassnmap/OriginalTargetRestorer.java
@@ -31,12 +31,14 @@ import org.camunda.bpm.engine.variable.Variables;
 import org.camunda.bpm.engine.variable.value.ObjectValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
 public class OriginalTargetRestorer implements JavaDelegate {
 
-    private ObjectMapper objectMapper = new ObjectMapper();
+    @Autowired
+    private ObjectMapper objectMapper;
     private static final Logger LOG = LoggerFactory.getLogger(OriginalTargetRestorer.class);
 
     @Override

--- a/scb-scanprocesses/combined-amass-nmap-process/src/main/resources/bpmn/combined_amass_nmap_process.bpmn
+++ b/scb-scanprocesses/combined-amass-nmap-process/src/main/resources/bpmn/combined_amass_nmap_process.bpmn
@@ -36,7 +36,7 @@
       <bpmn:incoming>SequenceFlow_16u7pin</bpmn:incoming>
     </bpmn:endEvent>
     <bpmn:exclusiveGateway id="ExclusiveGateway_19lm6ef" name="is automated run?">
-      <bpmn:incoming>SequenceFlow_0x38sun</bpmn:incoming>
+      <bpmn:incoming>SequenceFlow_0k50e6l</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_1r4mrzm</bpmn:outgoing>
       <bpmn:outgoing>SequenceFlow_1k9fyw2</bpmn:outgoing>
     </bpmn:exclusiveGateway>
@@ -47,7 +47,7 @@
       <bpmn:incoming>SequenceFlow_1r4mrzm</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_0y61th0</bpmn:outgoing>
     </bpmn:userTask>
-    <bpmn:sequenceFlow id="SequenceFlow_0x38sun" sourceRef="ServiceTask_DoNmapScan" targetRef="ExclusiveGateway_19lm6ef" />
+    <bpmn:sequenceFlow id="SequenceFlow_0x38sun" sourceRef="ServiceTask_DoNmapScan" targetRef="Task_0epb1nj" />
     <bpmn:sequenceFlow id="SequenceFlow_1r4mrzm" name="no" sourceRef="ExclusiveGateway_19lm6ef" targetRef="UserTask_ApproveResults">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${PROCESS_AUTOMATED == false}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
@@ -76,6 +76,11 @@
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${PROCESS_RESULT_APPROVED != 'approved'}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="SequenceFlow_16u7pin" sourceRef="ServiceTask_CreateSummary" targetRef="EndEvent_08aeh6a" />
+    <bpmn:serviceTask id="Task_0epb1nj" name="Restore original Target" camunda:delegateExpression="${originalTargetRestorer}">
+      <bpmn:incoming>SequenceFlow_0x38sun</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0k50e6l</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="SequenceFlow_0k50e6l" sourceRef="Task_0epb1nj" targetRef="ExclusiveGateway_19lm6ef" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="amass-nmap-process">
@@ -110,35 +115,35 @@
         <dc:Bounds x="513" y="288" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="EndEvent_08aeh6a_di" bpmnElement="EndEvent_08aeh6a">
-        <dc:Bounds x="1082" y="310" width="36" height="36" />
+        <dc:Bounds x="1198" y="310" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1075" y="357" width="67" height="14" />
+          <dc:Bounds x="1191" y="357" width="67" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_19lm6ef_di" bpmnElement="ExclusiveGateway_19lm6ef" isMarkerVisible="true">
-        <dc:Bounds x="735" y="303" width="50" height="50" />
+        <dc:Bounds x="851" y="303" width="50" height="50" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="716" y="356" width="89" height="14" />
+          <dc:Bounds x="832" y="356" width="89" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="UserTask_0tqqu7a_di" bpmnElement="UserTask_ApproveResults">
-        <dc:Bounds x="808" y="162" width="100" height="80" />
+        <dc:Bounds x="924" y="162" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="SequenceFlow_0x38sun_di" bpmnElement="SequenceFlow_0x38sun">
         <di:waypoint x="613" y="328" />
-        <di:waypoint x="735" y="328" />
+        <di:waypoint x="707" y="328" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1r4mrzm_di" bpmnElement="SequenceFlow_1r4mrzm">
-        <di:waypoint x="760" y="303" />
-        <di:waypoint x="760" y="202" />
-        <di:waypoint x="808" y="202" />
+        <di:waypoint x="876" y="303" />
+        <di:waypoint x="876" y="202" />
+        <di:waypoint x="924" y="202" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="769" y="250" width="13" height="14" />
+          <dc:Bounds x="885" y="250" width="13" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0y61th0_di" bpmnElement="SequenceFlow_0y61th0">
-        <di:waypoint x="908" y="202" />
-        <di:waypoint x="949" y="202" />
+        <di:waypoint x="1024" y="202" />
+        <di:waypoint x="1065" y="202" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="DataObjectReference_0juw01a_di" bpmnElement="DataObjectReference_0juw01a">
         <dc:Bounds x="270" y="337" width="36" height="50" />
@@ -153,39 +158,46 @@
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_1qxfzbc_di" bpmnElement="ServiceTask_CreateSummary">
-        <dc:Bounds x="924" y="288" width="100" height="80" />
+        <dc:Bounds x="1040" y="288" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="SequenceFlow_1k9fyw2_di" bpmnElement="SequenceFlow_1k9fyw2">
-        <di:waypoint x="785" y="328" />
-        <di:waypoint x="924" y="328" />
+        <di:waypoint x="901" y="328" />
+        <di:waypoint x="1040" y="328" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="852" y="310" width="17" height="14" />
+          <dc:Bounds x="968" y="310" width="17" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="ExclusiveGateway_1tkxll0_di" bpmnElement="ExclusiveGateway_1tkxll0" isMarkerVisible="true">
-        <dc:Bounds x="949" y="177" width="50" height="50" />
+        <dc:Bounds x="1065" y="177" width="50" height="50" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="948" y="157" width="52" height="14" />
+          <dc:Bounds x="1064" y="157" width="52" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="SequenceFlow_0u5weoe_di" bpmnElement="SequenceFlow_0u5weoe">
-        <di:waypoint x="974" y="227" />
-        <di:waypoint x="974" y="288" />
+        <di:waypoint x="1090" y="227" />
+        <di:waypoint x="1090" y="288" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="982" y="244" width="17" height="14" />
+          <dc:Bounds x="1098" y="244" width="17" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0mvz7h9_di" bpmnElement="SequenceFlow_0mvz7h9">
-        <di:waypoint x="999" y="202" />
-        <di:waypoint x="1100" y="202" />
-        <di:waypoint x="1100" y="310" />
+        <di:waypoint x="1115" y="202" />
+        <di:waypoint x="1216" y="202" />
+        <di:waypoint x="1216" y="310" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1047" y="183" width="13" height="14" />
+          <dc:Bounds x="1163" y="183" width="13" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_16u7pin_di" bpmnElement="SequenceFlow_16u7pin">
-        <di:waypoint x="1024" y="328" />
-        <di:waypoint x="1082" y="328" />
+        <di:waypoint x="1140" y="328" />
+        <di:waypoint x="1198" y="328" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="ServiceTask_0epb1nj_di" bpmnElement="Task_0epb1nj">
+        <dc:Bounds x="707" y="288" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0k50e6l_di" bpmnElement="SequenceFlow_0k50e6l">
+        <di:waypoint x="807" y="328" />
+        <di:waypoint x="851" y="328" />
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/scb-scanprocesses/combined-amass-nmap-process/src/main/resources/forms/amass-nmap/approve-results.html
+++ b/scb-scanprocesses/combined-amass-nmap-process/src/main/resources/forms/amass-nmap/approve-results.html
@@ -50,7 +50,7 @@
     </script>
 
     <h2>
-        Port scan results for subdomains of "{{ firstTarget.name }}"
+        Port scan results for subdomains of "{{ firstTarget.location }}"
     </h2>
 
     <div class="row">


### PR DESCRIPTION
- Extended amass-nmap process so that the original amass target (containing the domain) will be restored at the end of the process. This is necessary, since during the security test process the original target (which is the amass input) is being replaced by the amass findings, which are the new targets for nmap.