### PR TITLE
Marked combined nmap-amass scan results as nmap

### DIFF
--- a/scb-persistenceproviders/defectdojo-persistenceprovider/src/main/java/io/securecodebox/persistence/DefectDojoPersistenceProvider.java
+++ b/scb-persistenceproviders/defectdojo-persistenceprovider/src/main/java/io/securecodebox/persistence/DefectDojoPersistenceProvider.java
@@ -212,6 +212,9 @@ public class DefectDojoPersistenceProvider implements PersistenceProvider {
         scannerDefectDojoMapping.put("nmap", "Nmap Scan");
         scannerDefectDojoMapping.put("zap", "ZAP Scan");
 
+        // Map amass-nmap raw results to be imported as Nmap Results
+        scannerDefectDojoMapping.put("amass-nmap", "Nmap Scan");
+
         // Nikto is a supported tool as well but currently not accessible for supported import.
         // Nikto thus will use Generic Findings Import.
 


### PR DESCRIPTION
This ensures that the results are imported using the raw nmap result importer in defect-dojo.