### PR TITLE
Add missing permissions to ci group

### DIFF
--- a/scb-engine/src/main/java/io/securecodebox/engine/helper/DefaultGroupConfiguration.java
+++ b/scb-engine/src/main/java/io/securecodebox/engine/helper/DefaultGroupConfiguration.java
@@ -75,13 +75,13 @@ public class DefaultGroupConfiguration extends AbstractCamundaConfiguration {
                 processEngine.getAuthorizationService(),
                 GROUP_CI,
                 Resources.PROCESS_DEFINITION,
-                Permissions.CREATE_INSTANCE
+                Permissions.CREATE_INSTANCE, Permissions.READ, Permissions.READ_HISTORY
         );
         createAuthorizationForGroup(
                 processEngine.getAuthorizationService(),
                 GROUP_CI,
                 Resources.PROCESS_INSTANCE,
-                Permissions.READ
+                Permissions.READ, Permissions.CREATE
         );
     }
 


### PR DESCRIPTION
Missing permission were preventing the default group from creating new securityTest since the camunda permissions were enforced on every rest api call.