### PR TITLE
Enable use of DefectDojo Persistence Provider Code without the secureCodeBox

### DIFF
--- a/scb-persistenceproviders/defectdojo-persistenceprovider/src/main/java/io/securecodebox/persistence/DefectDojoLoopException.java
+++ b/scb-persistenceproviders/defectdojo-persistenceprovider/src/main/java/io/securecodebox/persistence/DefectDojoLoopException.java
@@ -16,41 +16,14 @@
  *  limitations under the License.
  * /
  */
-package io.securecodebox.persistence.models;
+package io.securecodebox.persistence;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
-public class EngagementResponse {
-    @JsonProperty
-    protected long id;
-
-    @JsonProperty
-    protected String name;
-
-    @JsonProperty("branch_tag")
-    protected String branch;
-
-    public long getId() {
-        return id;
+public class DefectDojoLoopException extends RuntimeException{
+    public DefectDojoLoopException(String message) {
+        super(message);
     }
 
-    public void setId(long id) {
-        this.id = id;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public String getBanch() {
-        return branch;
-    }
-
-    public void setBranch(String branch) {
-        this.branch = branch;
+    public DefectDojoLoopException(String message, Throwable cause) {
+        super(message, cause);
     }
 }

--- a/scb-persistenceproviders/defectdojo-persistenceprovider/src/main/java/io/securecodebox/persistence/DefectDojoPersistenceProvider.java
+++ b/scb-persistenceproviders/defectdojo-persistenceprovider/src/main/java/io/securecodebox/persistence/DefectDojoPersistenceProvider.java
@@ -197,6 +197,9 @@ public class DefectDojoPersistenceProvider implements PersistenceProvider {
         engagementPayload.setTargetEnd(currentDate());
         engagementPayload.setStatus(EngagementPayload.Status.COMPLETED);
 
+        engagementPayload.getTags().add("secureCodeBox");
+        engagementPayload.getTags().add("automated");
+
         return defectDojoService.createEngagement(engagementPayload);
     }
 

--- a/scb-persistenceproviders/defectdojo-persistenceprovider/src/main/java/io/securecodebox/persistence/DefectDojoService.java
+++ b/scb-persistenceproviders/defectdojo-persistenceprovider/src/main/java/io/securecodebox/persistence/DefectDojoService.java
@@ -213,16 +213,17 @@ public class DefectDojoService {
             throw new DefectDojoPersistenceException("Failed to attach findings to engagement.");
         }
     }
-    public ImportScanResponse createFindingsForEngagementName(String engagementName, String rawResults, String defectDojoScanName, long productId){
-        createFindingsForEngagementName(engagementName, rawResults, defectDojoScanName, productId, new EngagementPayload());
+    public ImportScanResponse createFindingsForEngagementName(String engagementName, String rawResults, String defectDojoScanName, long productId, long lead){
+        return createFindingsForEngagementName(engagementName, rawResults, defectDojoScanName, productId, lead, new EngagementPayload());
     }
 
-    public ImportScanResponse createFindingsForEngagementName(String engagementName, String rawResults, String defectDojoScanName, long productId, EngagementPayload engagementPayload){
+    public ImportScanResponse createFindingsForEngagementName(String engagementName, String rawResults, String defectDojoScanName, long productId, long lead, EngagementPayload engagementPayload){
         Long engagementId = getEngagementIdByEngagementName(engagementName, productId).orElseGet(() -> {
             engagementPayload.setName(engagementName);
             engagementPayload.setProduct(productId);
             engagementPayload.setTargetStart(currentDate());
             engagementPayload.setTargetEnd(currentDate());
+            engagementPayload.setLead(lead);
             return createEngagement(engagementPayload).getId();
         });
 
@@ -256,24 +257,4 @@ public class DefectDojoService {
         LOG.warn("Engagement with name '{}' not found.", engagementName);
         return Optional.empty();
     }
-
-    public static void main(String[] args) {
-        DefectDojoService dd = new DefectDojoService();
-
-        dd.defectDojoUrl = "http://defectdojo.default.minikube.local:8080";
-        dd.defectDojoDefaultUserName = "admin";
-        dd.defectDojoApiKey = "...";
-
-        EngagementPayload engagement = new EngagementPayload();
-        engagement.setBranch("fix/stuff");
-
-        dd.createFindingsForEngagementName(
-                "NMAP fix/stuff",
-                "<?xml version=\"1.0\" encoding=\"UTF-8\"?><!DOCTYPE nmaprun>...</nmaprun>",
-                "Nmap Scan",
-                1,
-                engagement
-        );
-    }
-
 }

--- a/scb-persistenceproviders/defectdojo-persistenceprovider/src/main/java/io/securecodebox/persistence/DefectDojoService.java
+++ b/scb-persistenceproviders/defectdojo-persistenceprovider/src/main/java/io/securecodebox/persistence/DefectDojoService.java
@@ -18,8 +18,8 @@
  */
 package io.securecodebox.persistence;
 
-
 import io.securecodebox.persistence.models.*;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -43,7 +43,10 @@ import java.time.Clock;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Optional;
+import java.util.Iterator;
 
 @Component
 @ConditionalOnProperty(name = "securecodebox.persistence.defectdojo.enabled", havingValue = "true")
@@ -181,8 +184,13 @@ public class DefectDojoService {
             throw new DefectDojoPersistenceException("Failed to create Engagement for SecurityTest", e);
         }
     }
-
     public ImportScanResponse createFindings(String rawResult, long engagementId, long lead, String currentDate,String defectDojoScanName) {
+        return createFindings(rawResult, engagementId, lead, currentDate,defectDojoScanName, "");
+    }
+    /**
+     * Till version 1.5.4. testName (in defectdojo _test_type_) must be defectDojoScanName, afterwards, you can have somethings else
+     */
+    public ImportScanResponse createFindings(String rawResult, long engagementId, long lead, String currentDate,String defectDojoScanName, String testName) {
         RestTemplate restTemplate = new RestTemplate();
         HttpHeaders headers = getHeaders();
         headers.setContentType(MediaType.MULTIPART_FORM_DATA);
@@ -193,7 +201,12 @@ public class DefectDojoService {
         mvn.add("lead", Long.toString(lead));
         mvn.add("scan_date", currentDate);
         mvn.add("scan_type", defectDojoScanName);
-
+        mvn.add("close_old_findings", "true");
+        mvn.add("skip_duplicates", "false");
+        
+        if(!testName.isEmpty())
+            mvn.add("test_type", testName);
+        
         try {
             ByteArrayResource contentsAsResource = new ByteArrayResource(rawResult.getBytes(StandardCharsets.UTF_8)) {
                 @Override
@@ -214,10 +227,10 @@ public class DefectDojoService {
         }
     }
     public ImportScanResponse createFindingsForEngagementName(String engagementName, String rawResults, String defectDojoScanName, long productId, long lead){
-        return createFindingsForEngagementName(engagementName, rawResults, defectDojoScanName, productId, lead, new EngagementPayload());
+        return createFindingsForEngagementName(engagementName, rawResults, defectDojoScanName, productId, lead, new EngagementPayload(), "");
     }
 
-    public ImportScanResponse createFindingsForEngagementName(String engagementName, String rawResults, String defectDojoScanName, long productId, long lead, EngagementPayload engagementPayload){
+    public ImportScanResponse createFindingsForEngagementName(String engagementName, String rawResults, String defectDojoScanName, long productId, long lead, EngagementPayload engagementPayload, String testName){
         Long engagementId = getEngagementIdByEngagementName(engagementName, productId).orElseGet(() -> {
             engagementPayload.setName(engagementName);
             engagementPayload.setProduct(productId);
@@ -227,9 +240,28 @@ public class DefectDojoService {
             return createEngagement(engagementPayload).getId();
         });
 
-        return createFindings(rawResults, engagementId, lead, currentDate(), defectDojoScanName);
+        return createFindings(rawResults, engagementId, lead, currentDate(), defectDojoScanName, testName);
     }
 
+    public ImportScanResponse createFindingsForEngagementName(String engagementName, String rawResults, String defectDojoScanName, String productName, long lead, EngagementPayload engagementPayload, String testName){
+        long productId = 0;
+        try {
+            productId = retrieveProductId(productName);
+        } catch(DefectDojoProductNotFound e) {
+            LOG.debug("Given product does not exists");
+        }
+        if(productId == 0) {
+            ProductResponse productResponse = createProduct(productName);
+            productId = productResponse.getId();
+        }
+        
+        return createFindingsForEngagementName(engagementName, rawResults, defectDojoScanName, productId, lead, engagementPayload, testName);
+    }
+
+    private Optional<Long> getEngagementIdByEngagementName(String engagementName, String productName){
+        long productId = retrieveProductId(productName);
+        return getEngagementIdByEngagementName(engagementName, productId, 0L);
+    }
     private Optional<Long> getEngagementIdByEngagementName(String engagementName, long productId){
         return getEngagementIdByEngagementName(engagementName, productId, 0L);
     }
@@ -256,5 +288,137 @@ public class DefectDojoService {
         }
         LOG.warn("Engagement with name '{}' not found.", engagementName);
         return Optional.empty();
+    }
+    public ProductResponse createProduct(String productName) {
+        RestTemplate restTemplate = new RestTemplate();
+        ProductPayload productPayload = new ProductPayload(productName, "Description missing");
+        HttpEntity<ProductPayload> payload = new HttpEntity<>(productPayload, getHeaders());
+
+        try {
+            ResponseEntity<ProductResponse> response = restTemplate.exchange(defectDojoUrl + "/api/v2/products/", HttpMethod.POST, payload, ProductResponse.class);
+            return response.getBody();
+        } catch (HttpClientErrorException e) {
+            LOG.warn("Failed to create product {}", e);
+            LOG.warn("Failure response body. {}", e.getResponseBodyAsString());
+            throw new DefectDojoPersistenceException("Failed to create product", e);
+        }
+    }
+
+    public void deleteUnusedBranches(List<String> existingBranches, String producName) {
+        long productId = retrieveProductId(producName);
+        deleteUnusedBranches(existingBranches, productId);
+    } 
+
+    /**
+     * Deletes engagements based on branch tag
+     * Be aware that the branch tag MUST be set, otherwise all engagments will be deleted
+     */
+    public void deleteUnusedBranches(List<String> existingBranches, long productId) {
+        RestTemplate restTemplate = new RestTemplate();
+        
+        //get existing branches
+        List<EngagementResponse> engagementPayloads = getEngagementsForProduct(productId, 0);
+        for(EngagementResponse engagementPayload : engagementPayloads) {
+            boolean branchExists = false;
+            for(String existingBranchName : existingBranches) {
+                if(existingBranchName.equals(engagementPayload.getBanch())) {
+                    branchExists = true;
+                    break;
+                }
+            }
+            if(!branchExists) {
+                deleteEnageament(engagementPayload.getId());
+                LOG.info("Deleted engagement with id " + engagementPayload.getId() + ", branch " + engagementPayload.getBanch());
+            }
+        }
+    }
+
+    private List<EngagementResponse> getEngagementsForProduct(long productId, long offset) throws DefectDojoLoopException{
+        if(offset > 9999) {
+            throw new DefectDojoLoopException("offset engagement products too much!");
+        }
+        UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(defectDojoUrl + "/api/v2/engagements")
+                .queryParam("product", Long.toString(productId))
+                .queryParam("limit", Long.toString(50L))
+                .queryParam("offset", Long.toString(offset));
+
+        RestTemplate restTemplate = new RestTemplate();
+        HttpEntity engagementRequest = new HttpEntity(getHeaders());
+
+        ResponseEntity<DefectDojoResponse<EngagementResponse>> engagementResponse = restTemplate.exchange(builder.toUriString(), HttpMethod.GET, engagementRequest, new ParameterizedTypeReference<DefectDojoResponse<EngagementResponse>>(){});
+        List<EngagementResponse> engagementPayloads = new LinkedList<EngagementResponse>();
+        for(EngagementResponse engagement : engagementResponse.getBody().getResults()){
+            engagementPayloads.add(engagement);
+        }
+        if(engagementResponse.getBody().getNext() != null){
+            engagementPayloads.addAll(getEngagementsForProduct(productId, offset + 1));;
+        }
+        return engagementPayloads;
+    }    
+    public void deleteEnageament(long engagementId){
+        RestTemplate restTemplate = new RestTemplate();
+
+        String uri = defectDojoUrl + "/api/v2/engagements/" + engagementId + "/?id=" + engagementId;
+        HttpEntity request = new HttpEntity(getHeaders());
+        try {
+            ResponseEntity<DefectDojoResponse> response = restTemplate.exchange(uri, HttpMethod.GET, request, DefectDojoResponse.class);
+        } catch (HttpClientErrorException e) {
+            LOG.warn("Failed to delete engagment {}, engagementId: " + engagementId, e);
+            LOG.warn("Failure response body. {}", e.getResponseBodyAsString());
+            throw new DefectDojoPersistenceException("Failed to delete product", e);
+        }
+    }
+
+    /* options is created as follows:
+        MultiValueMap<String, String> mvn = new LinkedMultiValueMap<>();
+        mvn.add("engagement", Long.toString(engagementId));
+     */
+    private List<Finding> getCurrentFindings(long engagementId, LinkedMultiValueMap<String, String> options){
+        RestTemplate restTemplate = new RestTemplate();
+
+        UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(defectDojoUrl + "/api/v2/findings/")
+                .queryParam("active", "true")
+                .queryParam("false_p", "false")
+                .queryParam("duplicate", "false")
+                .queryParam("test__engagement", Long.toString(engagementId));
+
+        if(options != null) {
+            builder = prepareParameters(options, builder);
+        }
+
+        HttpEntity request = new HttpEntity(getHeaders());
+        try {
+            ResponseEntity<DefectDojoResponse<Finding>> response = restTemplate.exchange(builder.toUriString(), HttpMethod.GET, request, new ParameterizedTypeReference<DefectDojoResponse<Finding>>(){});
+            List<Finding> findings = new LinkedList<Finding>();
+            for(Finding finding : response.getBody().getResults()){
+                findings.add(finding);
+            }
+            return findings;
+        } catch (HttpClientErrorException e) {
+            LOG.warn("Failed to get findings {}, engagementId: " + engagementId, e);
+            LOG.warn("Failure response body. {}", e.getResponseBodyAsString());
+            throw new DefectDojoPersistenceException("Failed to get findings", e);
+        }
+    }
+    private UriComponentsBuilder prepareParameters(LinkedMultiValueMap<String, String> queryParameters, UriComponentsBuilder builder) {
+        Iterator<String> it = queryParameters.keySet().iterator();
+     
+        while(it.hasNext()){
+            String theKey = (String)it.next();
+            builder.replaceQueryParam(theKey, queryParameters.getFirst(theKey));
+        }
+        return builder;
+    }    
+
+    public List<Finding> receiveNonHandeldFindings(String productName, String engagementName, String minimumServerity, LinkedMultiValueMap<String, String> options){
+        Long engagementId = getEngagementIdByEngagementName(engagementName, productName).orElse(0L);
+        //getCurrentFindings
+        List<Finding> findings = new LinkedList<Finding>();
+        for (String serverity : Finding.getServeritiesAndHigherServerities(minimumServerity)) {
+            LinkedMultiValueMap<String, String> optionTemp = options.clone();
+            optionTemp.add("serverity", serverity);    
+            findings.addAll(getCurrentFindings(engagementId, optionTemp));
+        }
+        return findings;
     }
 }

--- a/scb-persistenceproviders/defectdojo-persistenceprovider/src/main/java/io/securecodebox/persistence/models/DefectDojoProduct.java
+++ b/scb-persistenceproviders/defectdojo-persistenceprovider/src/main/java/io/securecodebox/persistence/models/DefectDojoProduct.java
@@ -21,4 +21,11 @@ public class DefectDojoProduct {
 
     @JsonProperty("authorized_users")
     List<String> authorizedUsers;
+
+    public DefectDojoProduct() {}
+
+    public DefectDojoProduct(String productName, String productDescription) {
+        name = productName;
+        description = productDescription;
+    }
 }

--- a/scb-persistenceproviders/defectdojo-persistenceprovider/src/main/java/io/securecodebox/persistence/models/EngagementPayload.java
+++ b/scb-persistenceproviders/defectdojo-persistenceprovider/src/main/java/io/securecodebox/persistence/models/EngagementPayload.java
@@ -63,7 +63,7 @@ public class EngagementPayload {
     protected String commitHash;
 
     @JsonProperty("branch_tag")
-    protected String branch;
+    public String branch;
 
     @JsonProperty("source_code_management_uri")
     protected String repo;
@@ -79,6 +79,9 @@ public class EngagementPayload {
 
     @JsonProperty
     protected String description;
+
+    @JsonProperty("deduplication_on_engagement")
+    protected boolean deduplicationOnEngagement;
 
     /**
      * Currently only contains the statuses relevant to us.

--- a/scb-persistenceproviders/defectdojo-persistenceprovider/src/main/java/io/securecodebox/persistence/models/EngagementPayload.java
+++ b/scb-persistenceproviders/defectdojo-persistenceprovider/src/main/java/io/securecodebox/persistence/models/EngagementPayload.java
@@ -23,6 +23,7 @@ import lombok.Data;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedList;
 import java.util.List;
 
 
@@ -50,7 +51,7 @@ public class EngagementPayload {
     protected Status status = Status.IN_PROGRESS;
 
     @JsonProperty
-    protected List<String> tags = Collections.emptyList();
+    protected List<String> tags = new LinkedList<>();
 
     @JsonProperty
     protected String tracker;

--- a/scb-persistenceproviders/defectdojo-persistenceprovider/src/main/java/io/securecodebox/persistence/models/EngagementPayload.java
+++ b/scb-persistenceproviders/defectdojo-persistenceprovider/src/main/java/io/securecodebox/persistence/models/EngagementPayload.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 
@@ -49,7 +50,7 @@ public class EngagementPayload {
     protected Status status = Status.IN_PROGRESS;
 
     @JsonProperty
-    protected List<String> tags = Arrays.asList("secureCodeBox", "automated");
+    protected List<String> tags = Collections.emptyList();
 
     @JsonProperty
     protected String tracker;

--- a/scb-persistenceproviders/defectdojo-persistenceprovider/src/main/java/io/securecodebox/persistence/models/EngagementResponse.java
+++ b/scb-persistenceproviders/defectdojo-persistenceprovider/src/main/java/io/securecodebox/persistence/models/EngagementResponse.java
@@ -24,11 +24,22 @@ public class EngagementResponse {
     @JsonProperty
     protected long id;
 
+    @JsonProperty
+    protected String name;
+
     public long getId() {
         return id;
     }
 
     public void setId(long id) {
         this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
     }
 }

--- a/scb-persistenceproviders/defectdojo-persistenceprovider/src/main/java/io/securecodebox/persistence/models/Finding.java
+++ b/scb-persistenceproviders/defectdojo-persistenceprovider/src/main/java/io/securecodebox/persistence/models/Finding.java
@@ -1,0 +1,85 @@
+/*
+ *
+ *  SecureCodeBox (SCB)
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ * /
+ */
+package io.securecodebox.persistence.models;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+
+
+@Data
+public class Finding {
+    @JsonProperty
+    protected long id;
+
+    @JsonProperty
+    protected String title;
+    
+    @JsonProperty
+    protected long cwe;
+
+    @JsonProperty
+    protected String cve;
+    @JsonProperty
+
+    protected String severity;
+    
+    @JsonProperty
+    protected String description;
+    
+    @JsonProperty
+    protected boolean active = true;
+    
+    @JsonProperty
+    protected boolean verified = true;
+    
+    @JsonProperty("false_p")
+    protected boolean falsePostive = false;
+    
+    @JsonProperty
+    protected boolean duplicate =  false;
+
+    @JsonProperty("is_Mitigated")
+    protected boolean isMitigated = false;
+
+    enum FindingSeverities {
+
+    }
+    public static final LinkedList<String> findingServerities = new LinkedList<String>(){{
+        add("Low");
+        add("Medium");
+        add("High");
+        add("Critical");
+    }};
+    public static LinkedList<String> getServeritiesAndHigherServerities(String minimumServerity){
+        LinkedList<String> severities = new LinkedList<String>();
+        boolean minimumFound = false;
+        for(String serverity : findingServerities) {
+            if(minimumFound || minimumServerity.equals(serverity)) {
+                minimumFound = true;
+                severities.add(serverity);
+            }
+        }
+
+        return severities;
+    }
+}

--- a/scb-persistenceproviders/defectdojo-persistenceprovider/src/main/java/io/securecodebox/persistence/models/ProductPayload.java
+++ b/scb-persistenceproviders/defectdojo-persistenceprovider/src/main/java/io/securecodebox/persistence/models/ProductPayload.java
@@ -1,0 +1,34 @@
+/*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*  	http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*/
+
+package io.securecodebox.persistence.models;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+import lombok.Data;
+
+@Data
+public class ProductPayload {
+    @JsonProperty
+    String name;
+
+    @JsonProperty
+    String description;
+
+    public ProductPayload(String productName, String productDescription) {
+        name = productName;
+        description = productDescription;
+    }
+}

--- a/scb-persistenceproviders/defectdojo-persistenceprovider/src/main/java/io/securecodebox/persistence/models/ProductResponse.java
+++ b/scb-persistenceproviders/defectdojo-persistenceprovider/src/main/java/io/securecodebox/persistence/models/ProductResponse.java
@@ -20,15 +20,12 @@ package io.securecodebox.persistence.models;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public class EngagementResponse {
+public class ProductResponse {
     @JsonProperty
     protected long id;
 
     @JsonProperty
     protected String name;
-
-    @JsonProperty("branch_tag")
-    protected String branch;
 
     public long getId() {
         return id;
@@ -44,13 +41,5 @@ public class EngagementResponse {
 
     public void setName(String name) {
         this.name = name;
-    }
-
-    public String getBanch() {
-        return branch;
-    }
-
-    public void setBranch(String branch) {
-        this.branch = branch;
     }
 }

--- a/scb-persistenceproviders/defectdojo-persistenceprovider/src/test/java/io/securecodebox/persistence/DefectDojoPersistenceProviderTest.java
+++ b/scb-persistenceproviders/defectdojo-persistenceprovider/src/test/java/io/securecodebox/persistence/DefectDojoPersistenceProviderTest.java
@@ -233,4 +233,13 @@ public class DefectDojoPersistenceProviderTest {
                 eq("Generic Findings Import")
         );
     }
+
+    @Test
+    public void createProduct() {
+        String productName = "mytestproduct";
+        defectDojoService.createProduct(productName);
+        verify(defectDojoService, times(1)).createProduct(
+            eq(productName)
+        );
+    }
 }

--- a/scb-persistenceproviders/defectdojo-persistenceprovider/src/test/java/io/securecodebox/persistence/DefectDojoPersistenceProviderTest.java
+++ b/scb-persistenceproviders/defectdojo-persistenceprovider/src/test/java/io/securecodebox/persistence/DefectDojoPersistenceProviderTest.java
@@ -140,6 +140,8 @@ public class DefectDojoPersistenceProviderTest {
         payload.setBuildServer(5l);
         payload.setScmServer(7l);
         payload.setOrchestrationEngine(9l);
+        payload.getTags().add("secureCodeBox");
+        payload.getTags().add("automated");
 
         persistenceProvider.persist(securityTest);
 


### PR DESCRIPTION
Adds a couple of new methods and minor changes in the DefectDojo Persistence Provider API, to reuse the code to write results to DefectDojo without a running secureCodeBox instance.

This should not interfere with the existing behaviour of the DefectDojo persistence provider when saving scan results.

Thanks @wurstbrot for kicking this of and contributing the majority of the code 👍