### PR TITLE
Reduce Database Write Clutter in Nmap Process

### DIFF
--- a/scb-engine/src/main/java/io/securecodebox/engine/execution/DefaultScanProcessExecution.java
+++ b/scb-engine/src/main/java/io/securecodebox/engine/execution/DefaultScanProcessExecution.java
@@ -135,6 +135,13 @@ public class DefaultScanProcessExecution implements ScanProcessExecution {
     }
 
     @Override
+    public void appendFindings(List<Finding> newFindings) {
+        List<Finding> findings = getJsonFromProcessVariableModifiable(DefaultFields.PROCESS_FINDINGS, Finding.class);
+        findings.addAll(newFindings);
+        writeToProcess(DefaultFields.PROCESS_FINDINGS, findings);
+    }
+
+    @Override
     public void clearTargets() {
         writeToProcess(DefaultFields.PROCESS_TARGETS, new LinkedList<>());
     }

--- a/scb-scanprocesses/combined-amass-nmap-process/src/main/java/io/securecodebox/scanprocesses/amassnmap/FilterHttpSecurityHeaders.java
+++ b/scb-scanprocesses/combined-amass-nmap-process/src/main/java/io/securecodebox/scanprocesses/amassnmap/FilterHttpSecurityHeaders.java
@@ -56,7 +56,7 @@ public class FilterHttpSecurityHeaders implements JavaDelegate {
         final long tStrategiesApplied = System.currentTimeMillis();
         final int numberOfAdditionalFindings = findings.size() - process.getFindings().size();
         clearFindings(process);
-        findings.forEach(changedFinding -> process.appendFinding(changedFinding));
+        process.appendFindings(findings);
         LOG.debug("http-headers strategies yielded {} additional findings; finding them took {}ms, storing them {}ms", numberOfAdditionalFindings, tStrategiesApplied - tStart, System.currentTimeMillis() - tStrategiesApplied);
     }
 

--- a/scb-sdk/src/main/java/io/securecodebox/model/execution/ScanProcessExecution.java
+++ b/scb-sdk/src/main/java/io/securecodebox/model/execution/ScanProcessExecution.java
@@ -89,6 +89,9 @@ public interface ScanProcessExecution {
     @JsonIgnore
     void appendFinding(Finding finding);
 
+    @JsonIgnore
+    void appendFindings(List<Finding> newFindings);
+
     void appendTarget(Target target);
 
     List<Target> getTargets();


### PR DESCRIPTION
The Nmap Process had previously written its findings multiple times to the database because it added them 1 after the other when the findings were completly processed.
This PR changes the behaviour and only persists them in one go.