### PR TITLE
Replace develop docker tag with unstable tag

### DIFF
--- a/.travis/deployDockerHub.sh
+++ b/.travis/deployDockerHub.sh
@@ -4,14 +4,17 @@ echo "Docker Login"
 echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
 echo "Pushing to Dockerhub"
 
-if [[ $TRAVIS_BRANCH =~ ^develop$ ]]
+if [[ $TRAVIS_BRANCH =~ ^master$ ]]
 then
-    echo "Develop Build: Tagging develop image"
-    echo $(docker tag $REPO:$TAG $REPO:develop)
-    echo $(docker tag $REPO:$TAG $REPO:develop-$TRAVIS_BUILD_NUMBER)
-    echo "Develop Build: Pushing develop image"
-    echo $(docker push $REPO:develop)
-    echo $(docker push $REPO:develop-$TRAVIS_BUILD_NUMBER)
+    echo "Develop Build: Tagging unstable image"
+    # Also tagging master branch name to keep backwards compat
+    echo $(docker tag $REPO:$TAG $REPO:master)
+    echo $(docker tag $REPO:$TAG $REPO:unstable)
+    echo $(docker tag $REPO:$TAG $REPO:unstable-$TRAVIS_BUILD_NUMBER)
+    echo "Develop Build: Pushing unstable image"
+    echo $(docker push $REPO:master)
+    echo $(docker push $REPO:unstable)
+    echo $(docker push $REPO:unstable-$TRAVIS_BUILD_NUMBER)
 elif [ "$TRAVIS_BRANCH" = "$TRAVIS_TAG" ]
 then
     echo "Tagged Release: Pushing versioned docker image." 


### PR DESCRIPTION
Replace develop docker tag with unstable tag build from the most current master branch commit.

As we don't have / use the develop branch anymore we need some other way to build and test our current development state.