### PR TITLE
Add scan durationInMs, startDate & endDate fields to SecurityTest and ScanProcessExecution Models

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <camunda.spring.boot.starter.version>3.2.0</camunda.spring.boot.starter.version>
         <!-- END IMPORTANT -->
 
-        <spring-boot.version>2.1.5.RELEASE</spring-boot.version>
+        <spring-boot.version>2.1.8.RELEASE</spring-boot.version>
         <swagger-version>2.9.0</swagger-version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>

--- a/scb-engine/pom.xml
+++ b/scb-engine/pom.xml
@@ -95,6 +95,11 @@
             <artifactId>camunda-bpm-spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jdk8</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/scb-engine/src/main/java/io/securecodebox/engine/execution/DefaultScanProcessExecution.java
+++ b/scb-engine/src/main/java/io/securecodebox/engine/execution/DefaultScanProcessExecution.java
@@ -28,11 +28,8 @@ import io.securecodebox.model.execution.Target;
 import io.securecodebox.model.findings.Finding;
 import io.securecodebox.scanprocess.ProcessVariableHelper;
 import org.camunda.bpm.engine.delegate.DelegateExecution;
-import org.camunda.bpm.engine.history.HistoricProcessInstance;
-import org.camunda.bpm.engine.runtime.ProcessInstance;
 import org.camunda.bpm.engine.variable.value.BooleanValue;
 import org.camunda.bpm.engine.variable.value.StringValue;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Configurable;
 import org.springframework.util.StringUtils;
 

--- a/scb-engine/src/main/java/io/securecodebox/engine/execution/DefaultScanProcessExecution.java
+++ b/scb-engine/src/main/java/io/securecodebox/engine/execution/DefaultScanProcessExecution.java
@@ -21,6 +21,7 @@ package io.securecodebox.engine.execution;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.securecodebox.constants.DefaultFields;
+import io.securecodebox.engine.service.ExecutionTimeService;
 import io.securecodebox.model.execution.ScanProcessExecution;
 import io.securecodebox.model.execution.Scanner;
 import io.securecodebox.model.execution.Target;
@@ -31,6 +32,7 @@ import org.camunda.bpm.engine.history.HistoricProcessInstance;
 import org.camunda.bpm.engine.runtime.ProcessInstance;
 import org.camunda.bpm.engine.variable.value.BooleanValue;
 import org.camunda.bpm.engine.variable.value.StringValue;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Configurable;
 import org.springframework.util.StringUtils;
 
@@ -51,6 +53,9 @@ public class DefaultScanProcessExecution implements ScanProcessExecution {
 
     @JsonIgnore
     protected DelegateExecution execution;
+
+    @JsonIgnore
+    public ExecutionTimeService executionTimeService;
 
     public DefaultScanProcessExecution(DelegateExecution execution) {
         this.execution = execution;
@@ -194,32 +199,14 @@ public class DefaultScanProcessExecution implements ScanProcessExecution {
         return (Map<String, String>) execution.getVariable(DefaultFields.PROCESS_META_DATA.name());
     }
 
-
-    @JsonIgnore
-    private Optional<HistoricProcessInstance> getHistoricProcessInstance(){
-        return execution.getProcessEngineServices()
-                .getHistoryService()
-                .createHistoricProcessInstanceQuery()
-                .processInstanceId(execution.getProcessInstanceId())
-                .list()
-                .stream()
-                .findFirst();
-    }
-
     @Override
     public Date getStartDate(){
-        return getHistoricProcessInstance()
-            .orElseThrow(() -> new RuntimeException("Failed to finding process"))
-            .getStartTime();
+        return executionTimeService.getStartDate();
     }
 
     @Override
     public Optional<Date> getEndDate(){
-        return Optional.ofNullable(
-            getHistoricProcessInstance()
-                .orElseThrow(() -> new RuntimeException("Failed to finding process"))
-                .getEndTime()
-        );
+        return executionTimeService.getEndDate();
     }
 
     @Override

--- a/scb-engine/src/main/java/io/securecodebox/engine/execution/DefaultScanProcessExecution.java
+++ b/scb-engine/src/main/java/io/securecodebox/engine/execution/DefaultScanProcessExecution.java
@@ -59,6 +59,7 @@ public class DefaultScanProcessExecution implements ScanProcessExecution {
 
     public DefaultScanProcessExecution(DelegateExecution execution) {
         this.execution = execution;
+        this.executionTimeService = new ExecutionTimeService(execution);
     }
 
     @Override

--- a/scb-engine/src/main/java/io/securecodebox/engine/execution/DefaultScanProcessExecution.java
+++ b/scb-engine/src/main/java/io/securecodebox/engine/execution/DefaultScanProcessExecution.java
@@ -225,8 +225,11 @@ public class DefaultScanProcessExecution implements ScanProcessExecution {
     @Override
     public Long getDurationInMilliSeconds() {
         Date startTime = getStartDate();
-        Date endTime = getEndDate().orElseGet(Date::new);
 
-        return endTime.getTime() - startTime.getTime();
+        if(startTime == null){
+            return null;
+        }
+
+        return getEndDate().orElseGet(Date::new).getTime() - startTime.getTime();
     }
 }

--- a/scb-engine/src/main/java/io/securecodebox/engine/service/ExecutionTimeService.java
+++ b/scb-engine/src/main/java/io/securecodebox/engine/service/ExecutionTimeService.java
@@ -1,0 +1,40 @@
+package io.securecodebox.engine.service;
+
+import org.camunda.bpm.engine.delegate.DelegateExecution;
+import org.camunda.bpm.engine.history.HistoricProcessInstance;
+
+import java.util.Date;
+import java.util.Optional;
+
+public class ExecutionTimeService {
+
+    DelegateExecution execution;
+
+    public ExecutionTimeService(DelegateExecution execution){
+        this.execution = execution;
+    }
+
+    private Optional<HistoricProcessInstance> getHistoricProcessInstance(){
+        return execution.getProcessEngineServices()
+                .getHistoryService()
+                .createHistoricProcessInstanceQuery()
+                .processInstanceId(execution.getProcessInstanceId())
+                .list()
+                .stream()
+                .findFirst();
+    }
+
+    public Date getStartDate(){
+        return getHistoricProcessInstance()
+                .orElseThrow(() -> new RuntimeException("Failed to finding process"))
+                .getStartTime();
+    }
+
+    public Optional<Date> getEndDate(){
+        return Optional.ofNullable(
+                getHistoricProcessInstance()
+                        .orElseThrow(() -> new RuntimeException("Failed to finding process"))
+                        .getEndTime()
+        );
+    }
+}

--- a/scb-engine/src/main/java/io/securecodebox/engine/service/ExecutionTimeService.java
+++ b/scb-engine/src/main/java/io/securecodebox/engine/service/ExecutionTimeService.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 
 public class ExecutionTimeService {
 
-    DelegateExecution execution;
+    private DelegateExecution execution;
 
     public ExecutionTimeService(DelegateExecution execution){
         this.execution = execution;

--- a/scb-engine/src/main/java/io/securecodebox/engine/service/SecurityTestService.java
+++ b/scb-engine/src/main/java/io/securecodebox/engine/service/SecurityTestService.java
@@ -39,6 +39,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -143,7 +144,7 @@ public class SecurityTestService {
         List<Target> targets = getListValue(variables, DefaultFields.PROCESS_TARGETS, Target.class);
         Map<String, String> metaData = (Map<String, String>) variables.get(DefaultFields.PROCESS_META_DATA.name()).getValue();
 
-        return new SecurityTest(id, context, name, targets.get(0), report, metaData, tenant);
+        return new SecurityTest(id, context, name, targets.get(0), report, metaData, tenant, process.getStartTime(), Optional.ofNullable(process.getEndTime()));
     }
 
     private <T> List<T> getListValue(Map<String, HistoricVariableInstance> variables, DefaultFields name, Class<T> type) {

--- a/scb-engine/src/test/java/io/securecodebox/engine/execution/DefaultScanProcessExecutionTest.java
+++ b/scb-engine/src/test/java/io/securecodebox/engine/execution/DefaultScanProcessExecutionTest.java
@@ -38,7 +38,6 @@ import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.mockito.stubbing.Answer;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.Date;
@@ -49,7 +48,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
 
 /**
  * @author Rüdiger Heins - iteratec GmbH

--- a/scb-engine/src/test/java/io/securecodebox/engine/execution/DefaultScanProcessExecutionTest.java
+++ b/scb-engine/src/test/java/io/securecodebox/engine/execution/DefaultScanProcessExecutionTest.java
@@ -38,6 +38,9 @@ import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.mockito.stubbing.Answer;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.Date;
 import java.util.Optional;
 import java.util.UUID;
@@ -54,7 +57,7 @@ import static org.mockito.Mockito.*;
  */
 public class DefaultScanProcessExecutionTest {
 
-    private static final String DEFAULT_EXECUTION = "{\"id\":\"5a4e9d37-09b0-4109-badd-d79dfa8fce2a\",\"context\":\"TEST_CONTEXT\",\"automated\":false,\"scanners\":[{\"id\":\"62fa8ffb-e3bc-433e-b322-9c02108c5171\",\"type\":\"Test_SCANNER\",\"findings\":[{\"id\":\"49bf7fd3-8512-4d73-a28f-608e493cd726\",\"name\":\"BAD_TEST_FINDIG\",\"description\":\"Some coder has tested this!\",\"category\":\"COOL_TEST_STUFF\",\"osi_layer\":\"NOT_APPLICABLE\",\"severity\":\"HIGH\",\"reference\":{\"id\":\"UNI_CODE_STUFF\",\"source\":\"RISCOOL\"},\"hint\":\"You might wan't to blame Rüdiger!\",\"attributes\":{\"TEST\":\"Kekse\",\"HORRIBLE\":\"Coke\"},\"location\":\"mett.brot.securecodebox.io\",\"false_positive\":false}],\"rawFindings\":\"[{\\\"pudding\\\":\\\"Bier\\\"}]\"}],\"startDate\":61514978400000,\"endDate\":61514978400000,\"durationInMilliSeconds\":0}";
+    private static final String DEFAULT_EXECUTION = "{\"id\":\"5a4e9d37-09b0-4109-badd-d79dfa8fce2a\",\"context\":\"TEST_CONTEXT\",\"automated\":false,\"scanners\":[{\"id\":\"62fa8ffb-e3bc-433e-b322-9c02108c5171\",\"type\":\"Test_SCANNER\",\"findings\":[{\"id\":\"49bf7fd3-8512-4d73-a28f-608e493cd726\",\"name\":\"BAD_TEST_FINDIG\",\"description\":\"Some coder has tested this!\",\"category\":\"COOL_TEST_STUFF\",\"osi_layer\":\"NOT_APPLICABLE\",\"severity\":\"HIGH\",\"reference\":{\"id\":\"UNI_CODE_STUFF\",\"source\":\"RISCOOL\"},\"hint\":\"You might wan't to blame Rüdiger!\",\"attributes\":{\"TEST\":\"Kekse\",\"HORRIBLE\":\"Coke\"},\"location\":\"mett.brot.securecodebox.io\",\"false_positive\":false}],\"rawFindings\":\"[{\\\"pudding\\\":\\\"Bier\\\"}]\"}],\"startDate\":504295320000,\"endDate\":504295620000,\"durationInMilliSeconds\":300000}";
     public static final String SCANNER_SERIALIZE_RESULT = "{\"id\":\"62fa8ffb-e3bc-433e-b322-9c02108c5171\",\"type\":\"Test_SCANNER\",\"findings\":[{\"id\":\"49bf7fd3-8512-4d73-a28f-608e493cd726\",\"name\":\"BAD_TEST_FINDIG\",\"description\":\"Some coder has tested this!\",\"category\":\"COOL_TEST_STUFF\",\"osi_layer\":\"NOT_APPLICABLE\",\"severity\":\"HIGH\",\"reference\":{\"id\":\"UNI_CODE_STUFF\",\"source\":\"RISCOOL\"},\"hint\":\"You might wan't to blame Rüdiger!\",\"attributes\":{\"TEST\":\"Kekse\",\"HORRIBLE\":\"Coke\"},\"location\":\"mett.brot.securecodebox.io\",\"false_positive\":false}],\"rawFindings\":\"[{\\\"pudding\\\":\\\"Bier\\\"}]\"}";
 
     String findingCache = "";
@@ -78,8 +81,12 @@ public class DefaultScanProcessExecutionTest {
 
         objectMapper.registerModule(new Jdk8Module());
 
-        when(executionTimeService.getStartDate()).thenReturn(new Date(2019, 4, 3));
-        when(executionTimeService.getEndDate()).thenReturn(Optional.of(new Date(2019, 4, 3)));
+        when(executionTimeService.getStartDate()).thenReturn(
+                Date.from(LocalDateTime.of(1985, 12, 24, 18, 2).toInstant(ZoneOffset.UTC))
+        );
+        when(executionTimeService.getEndDate()).thenReturn(Optional.of(
+                Date.from(LocalDateTime.of(1985, 12, 24, 18, 7).toInstant(ZoneOffset.UTC))
+        ));
         underTest.executionTimeService = executionTimeService;
 
         when(processExecutionFactory.get(execution)).thenReturn(underTest);

--- a/scb-engine/src/test/java/io/securecodebox/engine/execution/DefaultScanProcessExecutionTest.java
+++ b/scb-engine/src/test/java/io/securecodebox/engine/execution/DefaultScanProcessExecutionTest.java
@@ -20,6 +20,7 @@
 package io.securecodebox.engine.execution;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import io.securecodebox.TestHelper;
 import io.securecodebox.constants.DefaultFields;
 import io.securecodebox.engine.service.ExecutionTimeService;
@@ -36,8 +37,6 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.mockito.stubbing.Answer;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.Date;
 import java.util.Optional;
@@ -55,7 +54,7 @@ import static org.mockito.Mockito.*;
  */
 public class DefaultScanProcessExecutionTest {
 
-    private static final String DEFAULT_EXECUTION = "{\"id\":\"5a4e9d37-09b0-4109-badd-d79dfa8fce2a\",\"context\":\"TEST_CONTEXT\",\"automated\":false,\"scanners\":[{\"id\":\"62fa8ffb-e3bc-433e-b322-9c02108c5171\",\"type\":\"Test_SCANNER\",\"findings\":[{\"id\":\"49bf7fd3-8512-4d73-a28f-608e493cd726\",\"name\":\"BAD_TEST_FINDIG\",\"description\":\"Some coder has tested this!\",\"category\":\"COOL_TEST_STUFF\",\"osi_layer\":\"NOT_APPLICABLE\",\"severity\":\"HIGH\",\"reference\":{\"id\":\"UNI_CODE_STUFF\",\"source\":\"RISCOOL\"},\"hint\":\"You might wan't to blame Rüdiger!\",\"attributes\":{\"TEST\":\"Kekse\",\"HORRIBLE\":\"Coke\"},\"location\":\"mett.brot.securecodebox.io\",\"false_positive\":false}],\"rawFindings\":\"[{\\\"pudding\\\":\\\"Bier\\\"}]\"}]}";
+    private static final String DEFAULT_EXECUTION = "{\"id\":\"5a4e9d37-09b0-4109-badd-d79dfa8fce2a\",\"context\":\"TEST_CONTEXT\",\"automated\":false,\"scanners\":[{\"id\":\"62fa8ffb-e3bc-433e-b322-9c02108c5171\",\"type\":\"Test_SCANNER\",\"findings\":[{\"id\":\"49bf7fd3-8512-4d73-a28f-608e493cd726\",\"name\":\"BAD_TEST_FINDIG\",\"description\":\"Some coder has tested this!\",\"category\":\"COOL_TEST_STUFF\",\"osi_layer\":\"NOT_APPLICABLE\",\"severity\":\"HIGH\",\"reference\":{\"id\":\"UNI_CODE_STUFF\",\"source\":\"RISCOOL\"},\"hint\":\"You might wan't to blame Rüdiger!\",\"attributes\":{\"TEST\":\"Kekse\",\"HORRIBLE\":\"Coke\"},\"location\":\"mett.brot.securecodebox.io\",\"false_positive\":false}],\"rawFindings\":\"[{\\\"pudding\\\":\\\"Bier\\\"}]\"}],\"startDate\":61514978400000,\"endDate\":61514978400000,\"durationInMilliSeconds\":0}";
     public static final String SCANNER_SERIALIZE_RESULT = "{\"id\":\"62fa8ffb-e3bc-433e-b322-9c02108c5171\",\"type\":\"Test_SCANNER\",\"findings\":[{\"id\":\"49bf7fd3-8512-4d73-a28f-608e493cd726\",\"name\":\"BAD_TEST_FINDIG\",\"description\":\"Some coder has tested this!\",\"category\":\"COOL_TEST_STUFF\",\"osi_layer\":\"NOT_APPLICABLE\",\"severity\":\"HIGH\",\"reference\":{\"id\":\"UNI_CODE_STUFF\",\"source\":\"RISCOOL\"},\"hint\":\"You might wan't to blame Rüdiger!\",\"attributes\":{\"TEST\":\"Kekse\",\"HORRIBLE\":\"Coke\"},\"location\":\"mett.brot.securecodebox.io\",\"false_positive\":false}],\"rawFindings\":\"[{\\\"pudding\\\":\\\"Bier\\\"}]\"}";
 
     String findingCache = "";
@@ -76,6 +75,8 @@ public class DefaultScanProcessExecutionTest {
     public void setUp() {
         MockitoAnnotations.initMocks(this);
         underTest = new DefaultScanProcessExecution(execution);
+
+        objectMapper.registerModule(new Jdk8Module());
 
         when(executionTimeService.getStartDate()).thenReturn(new Date(2019, 4, 3));
         when(executionTimeService.getEndDate()).thenReturn(Optional.of(new Date(2019, 4, 3)));
@@ -101,8 +102,10 @@ public class DefaultScanProcessExecutionTest {
     public void testSerialize() throws Exception {
         DelegateExecution process = mockDelegateExcecution();
 
-        ScanProcessExecution execution = new DefaultScanProcessExecution(process);
-        String s = objectMapper.writeValueAsString(execution);
+        DefaultScanProcessExecution execution = new DefaultScanProcessExecution(process);
+
+        execution.executionTimeService = executionTimeService;
+        String s = objectMapper.writeValueAsString((ScanProcessExecution) execution);
 
         System.out.println(s);
         assertEquals(DEFAULT_EXECUTION, s);

--- a/scb-engine/src/test/java/io/securecodebox/engine/execution/DefaultScanProcessExecutionTest.java
+++ b/scb-engine/src/test/java/io/securecodebox/engine/execution/DefaultScanProcessExecutionTest.java
@@ -22,6 +22,7 @@ package io.securecodebox.engine.execution;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.securecodebox.TestHelper;
 import io.securecodebox.constants.DefaultFields;
+import io.securecodebox.engine.service.ExecutionTimeService;
 import io.securecodebox.model.execution.ScanProcessExecution;
 import io.securecodebox.model.execution.ScanProcessExecutionFactory;
 import io.securecodebox.model.findings.OsiLayer;
@@ -35,19 +36,18 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.mockito.stubbing.Answer;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.util.ReflectionTestUtils;
 
+import java.util.Date;
+import java.util.Optional;
 import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.atLeastOnce;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 /**
  * @author Rüdiger Heins - iteratec GmbH
@@ -66,29 +66,35 @@ public class DefaultScanProcessExecutionTest {
     @Mock
     ScanProcessExecutionFactory processExecutionFactory;
     @Mock
-    DelegateExecution executionMock;
+    DelegateExecution execution;
+    @Mock
+    ExecutionTimeService executionTimeService;
 
     DefaultScanProcessExecution underTest;
 
     @Before
     public void setUp() {
         MockitoAnnotations.initMocks(this);
-        underTest = new DefaultScanProcessExecution(executionMock);
+        underTest = new DefaultScanProcessExecution(execution);
 
-        when(processExecutionFactory.get(executionMock)).thenReturn(underTest);
-        when(executionMock.hasVariable(eq(DefaultFields.PROCESS_FINDINGS.name()))).thenReturn(true);
-        when(executionMock.getVariable(eq(DefaultFields.PROCESS_FINDINGS.name()))).thenAnswer((answer) -> findingCache);
+        when(executionTimeService.getStartDate()).thenReturn(new Date(2019, 4, 3));
+        when(executionTimeService.getEndDate()).thenReturn(Optional.of(new Date(2019, 4, 3)));
+        underTest.executionTimeService = executionTimeService;
+
+        when(processExecutionFactory.get(execution)).thenReturn(underTest);
+        when(execution.hasVariable(eq(DefaultFields.PROCESS_FINDINGS.name()))).thenReturn(true);
+        when(execution.getVariable(eq(DefaultFields.PROCESS_FINDINGS.name()))).thenAnswer((answer) -> findingCache);
         doAnswer((Answer) invocation -> {
             findingCache = (String) ((ObjectValueImpl)invocation.getArgument(1)).getValue();
             return Void.TYPE;
-        }).when(executionMock).setVariable(eq(DefaultFields.PROCESS_FINDINGS.name()), any());
+        }).when(execution).setVariable(eq(DefaultFields.PROCESS_FINDINGS.name()), any());
 
-        when(executionMock.hasVariable(eq(DefaultFields.PROCESS_TARGETS.name()))).thenReturn(true);
-        when(executionMock.getVariable(eq(DefaultFields.PROCESS_TARGETS.name()))).thenAnswer((answer) -> targetCache);
+        when(execution.hasVariable(eq(DefaultFields.PROCESS_TARGETS.name()))).thenReturn(true);
+        when(execution.getVariable(eq(DefaultFields.PROCESS_TARGETS.name()))).thenAnswer((answer) -> targetCache);
         doAnswer((Answer) invocation -> {
             targetCache = (String) ((ObjectValueImpl)invocation.getArgument(1)).getValue();
             return Void.TYPE;
-        }).when(executionMock).setVariable(eq(DefaultFields.PROCESS_TARGETS.name()), any());
+        }).when(execution).setVariable(eq(DefaultFields.PROCESS_TARGETS.name()), any());
     }
 
     @Test
@@ -126,9 +132,9 @@ public class DefaultScanProcessExecutionTest {
         underTest.appendFinding(TestHelper.createBasicFinding(finding1Id));
         underTest.appendFinding(TestHelper.createBasicFindingDifferent(finding2Id));
 
-        Mockito.verify(executionMock, times(2)).setVariable(eq(DefaultFields.PROCESS_FINDINGS.name()), any());
+        Mockito.verify(execution, times(2)).setVariable(eq(DefaultFields.PROCESS_FINDINGS.name()), any());
 
-        ScanProcessExecution processExecution = processExecutionFactory.get(executionMock);
+        ScanProcessExecution processExecution = processExecutionFactory.get(execution);
 
         assertEquals(2, processExecution.getFindings().size());
 
@@ -163,9 +169,9 @@ public class DefaultScanProcessExecutionTest {
         //
         underTest.clearFindings();
 
-        Mockito.verify(executionMock, atLeastOnce()).getVariable(eq(DefaultFields.PROCESS_FINDINGS.name()));
-        Mockito.verify(executionMock, times(3)).setVariable(eq(DefaultFields.PROCESS_FINDINGS.name()), any());
-        Mockito.verifyNoMoreInteractions(executionMock);
+        Mockito.verify(execution, atLeastOnce()).getVariable(eq(DefaultFields.PROCESS_FINDINGS.name()));
+        Mockito.verify(execution, times(3)).setVariable(eq(DefaultFields.PROCESS_FINDINGS.name()), any());
+        Mockito.verifyNoMoreInteractions(execution);
         assertEquals(0, processExecution.getFindings().size());
     }
 
@@ -177,9 +183,9 @@ public class DefaultScanProcessExecutionTest {
         underTest.appendTarget(TestHelper.createBaiscTarget());
         underTest.appendTarget(TestHelper.createTarget("http://w1.w2.www", "some wired"));
 
-        Mockito.verify(executionMock, times(2)).setVariable(eq(DefaultFields.PROCESS_TARGETS.name()), any());
+        Mockito.verify(execution, times(2)).setVariable(eq(DefaultFields.PROCESS_TARGETS.name()), any());
 
-        ScanProcessExecution processExecution = processExecutionFactory.get(executionMock);
+        ScanProcessExecution processExecution = processExecutionFactory.get(execution);
 
         assertEquals(2, processExecution.getTargets().size());
 
@@ -201,9 +207,9 @@ public class DefaultScanProcessExecutionTest {
         // Clear targets
         //
         underTest.clearTargets();
-        Mockito.verify(executionMock, atLeastOnce()).getVariable(eq(DefaultFields.PROCESS_TARGETS.name()));
-        Mockito.verify(executionMock, times(3)).setVariable(eq(DefaultFields.PROCESS_TARGETS.name()), any());
-        Mockito.verifyNoMoreInteractions(executionMock);
+        Mockito.verify(execution, atLeastOnce()).getVariable(eq(DefaultFields.PROCESS_TARGETS.name()));
+        Mockito.verify(execution, times(3)).setVariable(eq(DefaultFields.PROCESS_TARGETS.name()), any());
+        Mockito.verifyNoMoreInteractions(execution);
         assertEquals(0, processExecution.getTargets().size());
 
     }

--- a/scb-persistenceproviders/elasticsearch-persistenceprovider/pom.xml
+++ b/scb-persistenceproviders/elasticsearch-persistenceprovider/pom.xml
@@ -71,6 +71,10 @@
             <version>1.2.1</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jdk8</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/scb-persistenceproviders/elasticsearch-persistenceprovider/src/main/java/io/securecodebox/persistence/elasticsearch/ElasticSearchPersistenceProvider.java
+++ b/scb-persistenceproviders/elasticsearch-persistenceprovider/src/main/java/io/securecodebox/persistence/elasticsearch/ElasticSearchPersistenceProvider.java
@@ -22,6 +22,7 @@ package io.securecodebox.persistence.elasticsearch;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import io.securecodebox.model.findings.Finding;
 import io.securecodebox.model.securitytest.SecurityTest;
 import io.securecodebox.persistence.PersistenceException;
@@ -168,6 +169,7 @@ public class ElasticSearchPersistenceProvider implements PersistenceProvider {
         }
 
         ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new Jdk8Module());
         try {
             checkForSecurityTestIdExistence(securityTest);
 

--- a/scb-persistenceproviders/elasticsearch-persistenceprovider/src/main/java/io/securecodebox/persistence/elasticsearch/ElasticSearchPersistenceProvider.java
+++ b/scb-persistenceproviders/elasticsearch-persistenceprovider/src/main/java/io/securecodebox/persistence/elasticsearch/ElasticSearchPersistenceProvider.java
@@ -338,6 +338,7 @@ public class ElasticSearchPersistenceProvider implements PersistenceProvider {
     private Map<String, Object> serializeAndRemove(Object object, String... toRemove) {
 
         ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new Jdk8Module());
         try {
             String jsonString = objectMapper.writeValueAsString(object);
             Map<String, Object> result = objectMapper.readValue(jsonString, new TypeReference<Map<String, Object>>() {
@@ -404,6 +405,7 @@ public class ElasticSearchPersistenceProvider implements PersistenceProvider {
             // The index-pattern "securecodebox*" doesn't exist, we need to create it along with the import objects
 
             ObjectMapper objectMapper = new ObjectMapper();
+            objectMapper.registerModule(new Jdk8Module());
 
             String kibanaFile = readFileResource("kibana-imports.json");
             List<KibanaData> dataElements = objectMapper.readValue(kibanaFile, objectMapper.getTypeFactory().constructCollectionType(List.class, KibanaData.class));

--- a/scb-persistenceproviders/s3-persistenceprovider/pom.xml
+++ b/scb-persistenceproviders/s3-persistenceprovider/pom.xml
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>RELEASE</version>
+            <version>2.6</version>
         </dependency>
     </dependencies>
 

--- a/scb-sdk/src/main/java/io/securecodebox/model/execution/ScanProcessExecution.java
+++ b/scb-sdk/src/main/java/io/securecodebox/model/execution/ScanProcessExecution.java
@@ -25,8 +25,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.securecodebox.model.findings.Finding;
 
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 
 /**
@@ -109,4 +111,13 @@ public interface ScanProcessExecution {
 
     @JsonProperty("name")
     void setName(String name);
+
+    @JsonProperty("durationInMilliSeconds")
+    Long getDurationInMilliSeconds();
+
+    @JsonProperty("startDate")
+    Date getStartDate();
+
+    @JsonProperty("endDate")
+    Optional<Date> getEndDate();
 }

--- a/scb-sdk/src/main/java/io/securecodebox/model/execution/ScanProcessExecution.java
+++ b/scb-sdk/src/main/java/io/securecodebox/model/execution/ScanProcessExecution.java
@@ -35,7 +35,7 @@ import java.util.UUID;
  * @author Rüdiger Heins - iteratec GmbH
  * @since 08.03.18
  */
-@JsonPropertyOrder({ "id", "context", "automated", "scanners", "scanner_type", "tenant_id" })
+@JsonPropertyOrder({ "id", "context", "automated", "scanners", "scanner_type", "tenant_id", "startDate", "endDate", "durationInMilliSeconds" })
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public interface ScanProcessExecution {
 

--- a/scb-sdk/src/main/java/io/securecodebox/model/securitytest/SecurityTest.java
+++ b/scb-sdk/src/main/java/io/securecodebox/model/securitytest/SecurityTest.java
@@ -115,7 +115,7 @@ public class SecurityTest extends AbstractSecurityTest {
             value = "Timestamp of when the security test was started.",
             example = "42"
     )
-    Date startedAt;
+    protected Date startedAt;
     public Date startedAt() {
         return startedAt;
     }
@@ -129,7 +129,7 @@ public class SecurityTest extends AbstractSecurityTest {
             value = "Timestamp of when the security test was ended. Null if still running, see finished attributes",
             example = "42"
     )
-    Optional<Date> endedAt;
+    protected Optional<Date> endedAt;
     public Optional<Date> getEndedAt() {
         return endedAt;
     }

--- a/scb-sdk/src/main/java/io/securecodebox/model/securitytest/SecurityTest.java
+++ b/scb-sdk/src/main/java/io/securecodebox/model/securitytest/SecurityTest.java
@@ -104,6 +104,9 @@ public class SecurityTest extends AbstractSecurityTest {
             example = "42"
     )
     public Long getDurationInMilliSeconds() {
+        if(startedAt == null){
+            return null;
+        }
         return endedAt.orElseGet(Date::new).getTime() - startedAt.getTime();
     }
 

--- a/scb-sdk/src/main/java/io/securecodebox/model/securitytest/SecurityTest.java
+++ b/scb-sdk/src/main/java/io/securecodebox/model/securitytest/SecurityTest.java
@@ -24,7 +24,9 @@ import io.securecodebox.model.execution.Target;
 import io.securecodebox.model.rest.Report;
 import io.swagger.annotations.ApiModelProperty;
 
+import java.util.Date;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 
 public class SecurityTest extends AbstractSecurityTest {
@@ -41,6 +43,10 @@ public class SecurityTest extends AbstractSecurityTest {
     }
 
     public SecurityTest(UUID id, String context, String name, Target target, Report report, Map<String, String> metaData, String tenant) {
+        this(id, context, name, target, report, metaData, tenant, null, Optional.empty());
+    }
+
+    public SecurityTest(UUID id, String context, String name, Target target, Report report, Map<String, String> metaData, String tenant, Date startedAt, Optional<Date> endedAt) {
         this.id = id;
         this.context = context;
         this.name = name;
@@ -48,6 +54,8 @@ public class SecurityTest extends AbstractSecurityTest {
         this.report = report;
         this.tenant = tenant;
         this.setMetaData(metaData);
+        this.startedAt = startedAt;
+        this.endedAt = endedAt;
     }
 
     public SecurityTest(ScanProcessExecution execution){
@@ -61,6 +69,8 @@ public class SecurityTest extends AbstractSecurityTest {
             this.target = execution.getTargets().get(0);
         }
         this.report = new Report(execution);
+        this.startedAt = execution.getStartDate();
+        this.endedAt = execution.getEndDate();
     }
 
     public Report getReport() {
@@ -86,5 +96,42 @@ public class SecurityTest extends AbstractSecurityTest {
     )
     public boolean isFinished(){
         return this.report != null;
+    }
+
+    @JsonProperty("durationInMilliSeconds")
+    @ApiModelProperty(
+            value = "Shows the current runtime duration or the time to completion in milli seconds.",
+            example = "42"
+    )
+    public Long getDurationInMilliSeconds() {
+        return endedAt.orElseGet(Date::new).getTime() - startedAt.getTime();
+    }
+
+    @JsonProperty("startedAt")
+    @ApiModelProperty(
+            value = "Timestamp of when the security test was started.",
+            example = "42"
+    )
+    Date startedAt;
+    public Date startedAt() {
+        return startedAt;
+    }
+
+    public void setStartedAt(Date startedAt) {
+        this.startedAt = startedAt;
+    }
+
+    @JsonProperty("endedAt")
+    @ApiModelProperty(
+            value = "Timestamp of when the security test was ended. Null if still running, see finished attributes",
+            example = "42"
+    )
+    Optional<Date> endedAt;
+    public Optional<Date> getEndedAt() {
+        return endedAt;
+    }
+
+    public void setEndedAt(Optional<Date> endedAt) {
+        this.endedAt = endedAt;
     }
 }


### PR DESCRIPTION
For better monitoring three new fields were added to the models.
These fields get automatically populated from the camunda backend.