### PR TITLE
Update java dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 sudo: true
 language: java
+jdk:
+  - openjdk8
 services:
 - docker
 cache:

--- a/dependency-check-suppression.xml
+++ b/dependency-check-suppression.xml
@@ -21,7 +21,7 @@
 <!--
     This file is used to suppress false positives in the dependency check
 -->
-<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.1.xsd">
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
 
     <!--
         The issue CVE-2008-0732 seems to only affect SUSE LINUX init scripts. We are not using them.
@@ -45,5 +45,20 @@
         <cve>CVE-2019-0232</cve>
     </suppress>
 
+    <suppress until="2020-01-01Z">
+        <!--
+        Introduced through: spring-security-core-5.2.0.RELEASE.jar
+        -->
+        <cve>CVE-2018-1258</cve>
+
+        <!--
+        Not fixable until camunda-spin updates its jackson dependency
+        Introduced through: camunda-spin-dataformat-all-1.6.3.jar/META-INF/maven/com.fasterxml.jackson.core/jackson-databind/pom.xml
+        -->
+        <cve>CVE-2019-14379</cve>
+        <cve>CVE-2018-19362</cve>
+        <cve>CVE-2018-19361</cve>
+        <cve>CVE-2018-19360</cve>
+    </suppress>
 
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <camunda.spring.boot.starter.version>3.2.0</camunda.spring.boot.starter.version>
         <!-- END IMPORTANT -->
 
-        <spring-boot.version>2.1.8.RELEASE</spring-boot.version>
+        <spring-boot.version>2.2.0.RELEASE</spring-boot.version>
         <swagger-version>2.9.0</swagger-version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
             please see org.camunda.bpm.springboot.project:camunda-bpm-spring-boot-starter-root
          -->
         <camunda.version>7.10.0</camunda.version>
-        <camunda.spring.boot.starter.version>3.2.0</camunda.spring.boot.starter.version>
+        <camunda.spring.boot.starter.version>3.2.7</camunda.spring.boot.starter.version>
         <!-- END IMPORTANT -->
 
         <spring-boot.version>2.2.0.RELEASE</spring-boot.version>

--- a/pom.xml
+++ b/pom.xml
@@ -256,7 +256,7 @@
                     <plugin>
                         <groupId>org.owasp</groupId>
                         <artifactId>dependency-check-maven</artifactId>
-                        <version>3.3.1</version>
+                        <version>5.2.2</version>
                         <configuration>
                             <failBuildOnCVSS>8</failBuildOnCVSS>
                             <format>ALL</format>

--- a/scb-persistenceproviders/s3-persistenceprovider/pom.xml
+++ b/scb-persistenceproviders/s3-persistenceprovider/pom.xml
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-s3</artifactId>
-            <version>1.11.453</version>
+            <version>1.11.653</version>
         </dependency>
         <dependency>
             <groupId>org.powermock</groupId>


### PR DESCRIPTION
- Update camunda-spring-boot-starter and spring-boot version iteself.
- Update dependency check (was really out of date before)
- Update aws s3 java client
- Add dependency check suppression for dependencies which seem to be unfixable at the moment. I scoped the suppression to be valid for the rest of the year, hoping that we can update the dependencies after that...
- Add travis jdk config. Travis has apparently updated the default jdk version to 11 which breaks (at the least) the nmap process.