### PR TITLE
Bugfixing the combined NMAP+SSH Scan

### DIFF
--- a/scb-scanprocesses/combined-nmap-ssh-process/src/main/java/io/securecodebox/scanprocess/NmapToSshTransformListener.java
+++ b/scb-scanprocesses/combined-nmap-ssh-process/src/main/java/io/securecodebox/scanprocess/NmapToSshTransformListener.java
@@ -13,7 +13,7 @@ import java.util.stream.Collectors;
 @Component
 public class NmapToSshTransformListener extends TransformFindingsToTargetsListener {
 
-    public void notify(DelegateExecution delegateExecution) throws Exception{
+    public void notify(DelegateExecution delegateExecution) throws Exception {
 
         List<Finding> findings = ProcessVariableHelper.readListFromValue(
                 (String) delegateExecution.getVariable(DefaultFields.PROCESS_FINDINGS.name()),
@@ -31,6 +31,7 @@ public class NmapToSshTransformListener extends TransformFindingsToTargetsListen
                     String port = finding.getAttribute(OpenPortAttributes.port).toString();
 
                     Target target = new Target();
+                    target.setName("SSH Scan for " + hostname);
                     target.setLocation(hostname + ":" + port);
 
                     return target;
@@ -38,9 +39,18 @@ public class NmapToSshTransformListener extends TransformFindingsToTargetsListen
 
         LOG.info("Created Targets out of Findings: " + newTargets);
 
-        delegateExecution.setVariable(DefaultFields.PROCESS_TARGETS.name(),
-                ProcessVariableHelper.generateObjectValue(newTargets)
-        );
+        if (!newTargets.isEmpty() && newTargets.size() > 0) {
+            // define the new SSH targets, based on the nmap port scan results
+            delegateExecution.setVariable(DefaultFields.PROCESS_TARGETS.name(),
+                    ProcessVariableHelper.generateObjectValue(newTargets)
+            );
+        }
+        else {
+            // if no new target had been found clear the target parameter (and skip the ssh scan)
+            delegateExecution.setVariable(DefaultFields.PROCESS_TARGETS.name(),
+                    ""
+            );
+        }
     }
 
 }

--- a/scb-scanprocesses/combined-nmap-ssh-process/src/main/resources/bpmn/combined-nmap-ssh-process.bpmn
+++ b/scb-scanprocesses/combined-nmap-ssh-process/src/main/resources/bpmn/combined-nmap-ssh-process.bpmn
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="2.2.4">
-  <bpmn:process id="combined-nmap-ssh-process" name="Nmap-SSH Scan" isExecutable="true" camunda:versionTag="3" camunda:historyTimeToLive="1">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="1.11.3">
+  <bpmn:process id="combined-nmap-ssh-process" name="NMAP-SSH Scan" isExecutable="true" camunda:versionTag="4" camunda:historyTimeToLive="1">
     <bpmn:startEvent id="StartEvent_Configure" name="target configured" camunda:formKey="embedded:app:forms/ssh/configure-target.html">
       <bpmn:extensionElements>
         <camunda:executionListener delegateExpression="${checkForAutomatedRunListener}" event="start" />
@@ -32,10 +32,11 @@
       <bpmn:outgoing>SequenceFlow_ResultRejected</bpmn:outgoing>
     </bpmn:exclusiveGateway>
     <bpmn:sequenceFlow id="SequenceFlow_ResultApproved" name="result approved" sourceRef="ExclusiveGateway_ResultApproved" targetRef="ServiceTask_CreateSummary2">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${PROCESS_RESULT_APPROVED == 'approved'}</bpmn:conditionExpression>
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression"><![CDATA[${PROCESS_RESULT_APPROVED == 'approved'}]]></bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:exclusiveGateway id="ExclusiveGateway_AutomatedFinish" name="is automated run?">
       <bpmn:incoming>SequenceFlow_189n3gl</bpmn:incoming>
+      <bpmn:incoming>SequenceFlow_0mor6jt</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_ManualFinish</bpmn:outgoing>
       <bpmn:outgoing>SequenceFlow_AutomatedFinish</bpmn:outgoing>
     </bpmn:exclusiveGateway>
@@ -61,7 +62,7 @@
     <bpmn:dataObjectReference id="DataObjectReference_0vhjx0n" name="PROCESS_FINDINGS" dataObjectRef="DataObject_0lpf2y8" />
     <bpmn:dataObject id="DataObject_0lpf2y8" />
     <bpmn:sequenceFlow id="SequenceFlow_ResultRejected" name="result rejected" sourceRef="ExclusiveGateway_ResultApproved" targetRef="DoesNothingTask">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${PROCESS_RESULT_APPROVED == 'disapproved'}</bpmn:conditionExpression>
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression"><![CDATA[${PROCESS_RESULT_APPROVED == 'disapproved'}]]></bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:task id="DoesNothingTask" name="Does Nothing">
       <bpmn:incoming>SequenceFlow_ResultRejected</bpmn:incoming>
@@ -69,7 +70,7 @@
     </bpmn:task>
     <bpmn:sequenceFlow id="SequenceFlow_1i44eck" sourceRef="DoesNothingTask" targetRef="ServiceTask_CreateSummary2" />
     <bpmn:sequenceFlow id="SequenceFlow_189n3gl" sourceRef="ServiceTask_DoSshScan" targetRef="ExclusiveGateway_AutomatedFinish" />
-    <bpmn:sequenceFlow id="SequenceFlow_1jd7u0j" sourceRef="ServiceTask_CreateSummary" targetRef="ServiceTask_DoSshScan" />
+    <bpmn:sequenceFlow id="SequenceFlow_1jd7u0j" sourceRef="ServiceTask_CreateSummary" targetRef="ExclusiveGateway_1p6rwgs" />
     <bpmn:serviceTask id="ServiceTask_CreateSummary" name="Create Report Summary" camunda:asyncBefore="true" camunda:delegateExpression="${summaryGeneratorDelegate}">
       <bpmn:extensionElements>
         <camunda:executionListener delegateExpression="${nmapToSshTransformListener}" event="end" />
@@ -78,9 +79,20 @@
       <bpmn:outgoing>SequenceFlow_1jd7u0j</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:serviceTask id="ServiceTask_DoSshScan" name="Run the SSH scan" camunda:asyncBefore="true" camunda:type="external" camunda:topic="ssh_webserverscan">
-      <bpmn:incoming>SequenceFlow_1jd7u0j</bpmn:incoming>
+      <bpmn:incoming>SequenceFlow_1p0owpd</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_189n3gl</bpmn:outgoing>
     </bpmn:serviceTask>
+    <bpmn:exclusiveGateway id="ExclusiveGateway_1p6rwgs" name="SSH Ports found?">
+      <bpmn:incoming>SequenceFlow_1jd7u0j</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_1p0owpd</bpmn:outgoing>
+      <bpmn:outgoing>SequenceFlow_0mor6jt</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="SequenceFlow_1p0owpd" name="SSH Port found&#10;&#10;" sourceRef="ExclusiveGateway_1p6rwgs" targetRef="ServiceTask_DoSshScan">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression"><![CDATA[${PROCESS_TARGETS != ""}]]></bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="SequenceFlow_0mor6jt" name="No SSH Port&#10;&#10;" sourceRef="ExclusiveGateway_1p6rwgs" targetRef="ExclusiveGateway_AutomatedFinish">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression"><![CDATA[${PROCESS_TARGETS == ""}]]></bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
     <bpmn:textAnnotation id="TextAnnotation_0lm3esn">
       <bpmn:text>results in a generic format</bpmn:text>
     </bpmn:textAnnotation>
@@ -95,8 +107,8 @@
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="SequenceFlow_093mevy_di" bpmnElement="SequenceFlow_TargetConfigured">
-        <di:waypoint x="64" y="328" />
-        <di:waypoint x="142" y="328" />
+        <di:waypoint xsi:type="dc:Point" x="64" y="328" />
+        <di:waypoint xsi:type="dc:Point" x="142" y="328" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="58" y="303" width="90" height="20" />
         </bpmndi:BPMNLabel>
@@ -108,15 +120,15 @@
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="SequenceFlow_0kjlgbs_di" bpmnElement="SequenceFlow_PortscanFinished">
-        <di:waypoint x="242" y="328" />
-        <di:waypoint x="390" y="328" />
+        <di:waypoint xsi:type="dc:Point" x="242" y="328" />
+        <di:waypoint xsi:type="dc:Point" x="328" y="328" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="777.9999999999998" y="459" width="38" height="40" />
+          <dc:Bounds x="716" y="459" width="38" height="38" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_00fmvcb_di" bpmnElement="SequenceFlow_ResultReviewed">
-        <di:waypoint x="1074" y="202" />
-        <di:waypoint x="1161" y="204" />
+        <di:waypoint xsi:type="dc:Point" x="1074" y="202" />
+        <di:waypoint xsi:type="dc:Point" x="1161" y="204" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="1195" y="176" width="74" height="14" />
         </bpmndi:BPMNLabel>
@@ -131,8 +143,8 @@
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="SequenceFlow_0gjifhk_di" bpmnElement="SequenceFlow_ResultApproved">
-        <di:waypoint x="1211" y="204" />
-        <di:waypoint x="1478" y="204" />
+        <di:waypoint xsi:type="dc:Point" x="1211" y="204" />
+        <di:waypoint xsi:type="dc:Point" x="1478" y="204" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="1402" y="144" width="76" height="14" />
         </bpmndi:BPMNLabel>
@@ -144,18 +156,18 @@
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="SequenceFlow_17bwrf0_di" bpmnElement="SequenceFlow_ManualFinish">
-        <di:waypoint x="863" y="303" />
-        <di:waypoint x="863" y="204" />
-        <di:waypoint x="974" y="204" />
+        <di:waypoint xsi:type="dc:Point" x="863" y="303" />
+        <di:waypoint xsi:type="dc:Point" x="863" y="204" />
+        <di:waypoint xsi:type="dc:Point" x="974" y="204" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="780" y="246" width="65" height="40" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0s3limw_di" bpmnElement="SequenceFlow_AutomatedFinish">
-        <di:waypoint x="863" y="353" />
-        <di:waypoint x="863" y="456" />
-        <di:waypoint x="1528" y="456" />
-        <di:waypoint x="1528" y="244" />
+        <di:waypoint xsi:type="dc:Point" x="863" y="353" />
+        <di:waypoint xsi:type="dc:Point" x="863" y="456" />
+        <di:waypoint xsi:type="dc:Point" x="1528" y="456" />
+        <di:waypoint xsi:type="dc:Point" x="1528" y="244" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="1194" y="482" width="81" height="14" />
         </bpmndi:BPMNLabel>
@@ -164,8 +176,8 @@
         <dc:Bounds x="142" y="288" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="SequenceFlow_150f8k2_di" bpmnElement="SequenceFlow_SummaryCreated">
-        <di:waypoint x="1578" y="204" />
-        <di:waypoint x="1710" y="204" />
+        <di:waypoint xsi:type="dc:Point" x="1578" y="204" />
+        <di:waypoint xsi:type="dc:Point" x="1710" y="204" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="1588" y="209" width="85" height="14" />
         </bpmndi:BPMNLabel>
@@ -183,13 +195,13 @@
         <dc:Bounds x="812" y="487" width="102" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Association_16qrr9w_di" bpmnElement="Association_16qrr9w">
-        <di:waypoint x="774" y="472" />
-        <di:waypoint x="812" y="489" />
+        <di:waypoint xsi:type="dc:Point" x="774" y="472" />
+        <di:waypoint xsi:type="dc:Point" x="812" y="489" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1z0e6c0_di" bpmnElement="SequenceFlow_ResultRejected">
-        <di:waypoint x="1186" y="179" />
-        <di:waypoint x="1186" y="65" />
-        <di:waypoint x="1314" y="65" />
+        <di:waypoint xsi:type="dc:Point" x="1186" y="179" />
+        <di:waypoint xsi:type="dc:Point" x="1186" y="65" />
+        <di:waypoint xsi:type="dc:Point" x="1314" y="65" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="1195" y="96.99999999999989" width="70" height="14" />
         </bpmndi:BPMNLabel>
@@ -198,27 +210,52 @@
         <dc:Bounds x="1314" y="25" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="SequenceFlow_1i44eck_di" bpmnElement="SequenceFlow_1i44eck">
-        <di:waypoint x="1414" y="65" />
-        <di:waypoint x="1528" y="65" />
-        <di:waypoint x="1528" y="164" />
+        <di:waypoint xsi:type="dc:Point" x="1414" y="65" />
+        <di:waypoint xsi:type="dc:Point" x="1528" y="65" />
+        <di:waypoint xsi:type="dc:Point" x="1528" y="164" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="1066" y="43.5" width="90" height="13" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_189n3gl_di" bpmnElement="SequenceFlow_189n3gl">
-        <di:waypoint x="731" y="328" />
-        <di:waypoint x="838" y="328" />
+        <di:waypoint xsi:type="dc:Point" x="731" y="328" />
+        <di:waypoint xsi:type="dc:Point" x="838" y="328" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1jd7u0j_di" bpmnElement="SequenceFlow_1jd7u0j">
-        <di:waypoint x="490" y="328" />
-        <di:waypoint x="631" y="328" />
+        <di:waypoint xsi:type="dc:Point" x="428" y="328" />
+        <di:waypoint xsi:type="dc:Point" x="477" y="328" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="407.5" y="303" width="90" height="20" />
+        </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="ServiceTask_0li6e0b_di" bpmnElement="ServiceTask_CreateSummary">
-        <dc:Bounds x="390" y="288" width="100" height="80" />
+        <dc:Bounds x="328" y="288" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_16sga74_di" bpmnElement="ServiceTask_DoSshScan">
         <dc:Bounds x="631" y="288" width="100" height="80" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ExclusiveGateway_1p6rwgs_di" bpmnElement="ExclusiveGateway_1p6rwgs" isMarkerVisible="true">
+        <dc:Bounds x="477.30499325236167" y="303" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="458" y="356" width="89" height="13" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1p0owpd_di" bpmnElement="SequenceFlow_1p0owpd">
+        <di:waypoint xsi:type="dc:Point" x="527" y="328" />
+        <di:waypoint xsi:type="dc:Point" x="631" y="328" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="542.0072463768116" y="306" width="77" height="38" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0mor6jt_di" bpmnElement="SequenceFlow_0mor6jt">
+        <di:waypoint xsi:type="dc:Point" x="502" y="303" />
+        <di:waypoint xsi:type="dc:Point" x="502" y="219" />
+        <di:waypoint xsi:type="dc:Point" x="713" y="219" />
+        <di:waypoint xsi:type="dc:Point" x="849" y="317" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="578" y="198" width="63" height="25" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
 </bpmn:definitions>


### PR DESCRIPTION
Added a new fallback in the case that no SSH ports are found by NMAP … to prevent process errors if so.

Error Situation:
```
2020-01-05 18:36:33.256  INFO 6 --- [aTaskExecutor-3] i.s.p.e.ElasticSearchPersistenceProvider : Persisting SecurityTest and Findings...
2020-01-05 18:36:33.257  INFO 6 --- [aTaskExecutor-3] s.s.l.TransformFindingsToTargetsListener : Created Targets out of Findings: []
```
**Scan failed for unknown reasons.**