### PR TITLE
Added name and description check for nikto scans to avoid NullPointer

### DIFF
--- a/scb-persistenceproviders/defectdojo-persistenceprovider/src/main/java/io/securecodebox/persistence/DefectDojoPersistenceProvider.java
+++ b/scb-persistenceproviders/defectdojo-persistenceprovider/src/main/java/io/securecodebox/persistence/DefectDojoPersistenceProvider.java
@@ -150,25 +150,37 @@ public class DefectDojoPersistenceProvider implements PersistenceProvider {
     }
 
     private List<String> getGenericResults(SecurityTest securityTest) {
-        final String CSV_HEADER = "date,title,cweid,url,severity,description,mitigation,impact,references,active,verified,falsepositive,duplicate";
+        final String CSV_HEADER = "date,title,cweid,url,severity,description,mitigation,impact,references,active," +
+                "verified,falsepositive,duplicate";
 
         List<Finding> findings = securityTest.getReport().getFindings();
 
         String genericFindingsCsv = Stream.concat(
                 Stream.of(CSV_HEADER),
-                findings.stream().map(finding -> MessageFormat.format(
-                        "{0},{1},,{2},{3},{4},,,,,,{5},{6}",
-                        currentDate(),
-                        finding.getName().replace(",", "  "),
-                        finding.getLocation().replace(",", "  "),
-                        finding.getSeverity(),
-                        finding.getDescription().replace(",", "  "),
-                        finding.isFalsePositive(),
-                        "false"
-                ))
+                findings.stream()
+                        .map(finding -> checkIfNameOrDescriptionIsNotNull(finding))
+                        .map(finding -> MessageFormat.format(
+                                "{0},{1},,{2},{3},{4},,,,,,{5},{6}",
+                                currentDate(),
+                                finding.getName().replace(",", "  "),
+                                finding.getLocation().replace(",", "  "),
+                                finding.getSeverity(),
+                                finding.getDescription().replace(",", "  "),
+                                finding.isFalsePositive(),
+                                "false"
+                        ))
         ).collect(Collectors.joining("\n"));
 
         return Collections.singletonList(genericFindingsCsv);
+    }
+
+    private Finding checkIfNameOrDescriptionIsNotNull(Finding finding) {
+        if (null == finding.getName()) {
+            finding.setName("");
+        } else if (null == finding.getDescription()) {
+            finding.setDescription("");
+        }
+        return finding;
     }
 
     private EngagementResponse createEngagement(SecurityTest securityTest) {


### PR DESCRIPTION
During Nikto scans it can occur that no name or description is available, which now will be checked and replaced with an empty string.  