### PR TITLE
nmap-nikto: Blackboxtest all HTTP(s) services, optional list with ports to scan by nikto

### DIFF
--- a/scb-scanprocesses/combined-nmap-nikto-process/pom.xml
+++ b/scb-scanprocesses/combined-nmap-nikto-process/pom.xml
@@ -30,6 +30,12 @@
             <version>5.4.2</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>2.10.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/scb-scanprocesses/combined-nmap-nikto-process/pom.xml
+++ b/scb-scanprocesses/combined-nmap-nikto-process/pom.xml
@@ -18,5 +18,26 @@
             <groupId>io.securecodebox.core</groupId>
             <artifactId>sdk</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.4.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.4.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.1</version>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/scb-scanprocesses/combined-nmap-nikto-process/pom.xml
+++ b/scb-scanprocesses/combined-nmap-nikto-process/pom.xml
@@ -30,12 +30,6 @@
             <version>5.4.2</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <version>2.10.0</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/scb-scanprocesses/combined-nmap-nikto-process/src/main/java/io/securecodebox/scanprocess/listener/NmapToNiktoTransformListener.java
+++ b/scb-scanprocesses/combined-nmap-nikto-process/src/main/java/io/securecodebox/scanprocess/listener/NmapToNiktoTransformListener.java
@@ -28,7 +28,7 @@ public class NmapToNiktoTransformListener extends TransformFindingsToTargetsList
      * @param openPorts          Open ports found by nmap
      * @return
      */
-    protected Set<String> filterIrrelevantPorts(Set<String> portsToScanByNikto, Set<String> openPorts) {
+    private Set<String> filterIrrelevantPorts(Set<String> portsToScanByNikto, Set<String> openPorts) {
         if (openPorts.equals(portsToScanByNikto))
             return portsToScanByNikto;
 
@@ -42,7 +42,7 @@ public class NmapToNiktoTransformListener extends TransformFindingsToTargetsList
      * @param target Target
      * @return Set with validated Ports
      */
-    protected Set<String> getRelevantPorts(Target target) {
+    private Set<String> getRelevantPorts(Target target) {
         // Create a Set to ensure every port is only scanned once per host
         Set<String> portsToScanByNikto = new HashSet<>();
 
@@ -68,7 +68,7 @@ public class NmapToNiktoTransformListener extends TransformFindingsToTargetsList
         return niktoPortList.isEmpty();
     }
 
-    protected Map<String, Set<String>> getOpenPortsPerTarget(List<Finding> findings) {
+    private Map<String, Set<String>> getOpenPortsPerTarget(List<Finding> findings) {
         Map<String, Set<String>> openPortsPerTarget = new HashMap<>();
         findings.stream()
                 .filter(finding -> finding.getCategory().equals("Open Port"))
@@ -88,14 +88,14 @@ public class NmapToNiktoTransformListener extends TransformFindingsToTargetsList
         return openPortsPerTarget;
     }
 
-    protected Set<Target> collectTargetsWithOpenPorts(List<Target> targets, Map<String, Set<String>> openPortsPerTarget) {
+    private Set<Target> collectTargetsWithOpenPorts(List<Target> targets, Map<String, Set<String>> openPortsPerTarget) {
         return targets.stream()
                 // remove targets with no open ports
                 .filter(target -> openPortsPerTarget.containsKey(target.getLocation()))
                 .collect(Collectors.toSet());
     }
 
-    protected void updateTargetsWithNiktoPorts(Set<Target> targets, Map<String, Set<String>> openPortsPerTarget) {
+    private void updateTargetsWithNiktoPorts(Set<Target> targets, Map<String, Set<String>> openPortsPerTarget) {
         targets.forEach(target -> {
             Set<String> portsToScanByNikto = this.getRelevantPorts(target);
             Set<String> filteredPorts = this.filterIrrelevantPorts(portsToScanByNikto, openPortsPerTarget.get(target.getLocation()));

--- a/scb-scanprocesses/combined-nmap-nikto-process/src/main/java/io/securecodebox/scanprocess/listener/NmapToNiktoTransformListener.java
+++ b/scb-scanprocesses/combined-nmap-nikto-process/src/main/java/io/securecodebox/scanprocess/listener/NmapToNiktoTransformListener.java
@@ -50,13 +50,12 @@ public class NmapToNiktoTransformListener extends TransformFindingsToTargetsList
         // Transform Comma separated ports into an Array
         String[] portArray = ((String) target.getAttributes().get("COMBINED_NMAP_NIKTO_PORTS")).split(",");
 
-        // Remove whitespaces before and after port
+        // Remove whitespaces before and after port and add to Collection
         for (String port : portArray) {
-            port = port.trim();
+            portsToScanByNikto.add(port.trim());
         }
 
         // Move portArray into a Set to ensure every Port is only scanned once for each  host
-        Collections.addAll(portsToScanByNikto, portArray);
         return portsToScanByNikto.stream()
                 // remove empty entries
                 .filter(port -> !port.isEmpty())
@@ -101,7 +100,7 @@ public class NmapToNiktoTransformListener extends TransformFindingsToTargetsList
         targets.forEach(target -> {
             Set<String> portsToScanByNikto = this.getRelevantPorts(target);
             Set<String> filteredPorts = this.filterIrrelevantPorts(portsToScanByNikto, openPortsPerTarget.get(target.getLocation()));
-            target.appendOrUpdateAttribute("NIKTO_PORTS", String.join(",", filteredPorts));
+            target.appendOrUpdateAttribute("NIKTO_PORTS", String.join(", ", filteredPorts));
         });
     }
 

--- a/scb-scanprocesses/combined-nmap-nikto-process/src/main/java/io/securecodebox/scanprocess/listener/NmapToNiktoTransformListener.java
+++ b/scb-scanprocesses/combined-nmap-nikto-process/src/main/java/io/securecodebox/scanprocess/listener/NmapToNiktoTransformListener.java
@@ -61,6 +61,12 @@ public class NmapToNiktoTransformListener extends TransformFindingsToTargetsList
         );
     }
 
+    /**
+     * Removes all closed ports from specified COMBINED_NMAP_NIKTO_PORTS
+     * @param portsToScanByNikto specified COMBINED_NMAP_NIKTO_PORTS
+     * @param openPorts Open ports found by nmap
+     * @return
+     */
     private Set<String> filterIrrelevantPorts(Set<String> portsToScanByNikto, Set<String> openPorts) {
         if (openPorts.equals(portsToScanByNikto))
             return portsToScanByNikto;
@@ -69,6 +75,11 @@ public class NmapToNiktoTransformListener extends TransformFindingsToTargetsList
         return portSet;
     }
 
+    /**
+     * Extracts the value for the COMBINED_NMAP_NIKTO_PORTS attribute and removes invalid input
+     * @param target Target
+     * @return Set with validated Ports
+     */
     private Set<String> getSanitizedPortSet(Target target) {
         // Create a Set to ensure every port is only scanned once per host
         Set<String> portsToScanByNikto = new HashSet<>();

--- a/scb-scanprocesses/combined-nmap-nikto-process/src/main/java/io/securecodebox/scanprocess/listener/NmapToNiktoTransformListener.java
+++ b/scb-scanprocesses/combined-nmap-nikto-process/src/main/java/io/securecodebox/scanprocess/listener/NmapToNiktoTransformListener.java
@@ -6,37 +6,88 @@ import io.securecodebox.model.findings.Finding;
 import io.securecodebox.scanprocess.ProcessVariableHelper;
 import org.camunda.bpm.engine.delegate.DelegateExecution;
 import org.springframework.stereotype.Component;
+import sun.rmi.runtime.Log;
 
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Component
 public class NmapToNiktoTransformListener extends TransformFindingsToTargetsListener {
 
-    public void notify(DelegateExecution delegateExecution) throws Exception{
+    public void notify(DelegateExecution delegateExecution) throws Exception {
         List<Finding> findings = ProcessVariableHelper.readListFromValue(
                 (String) delegateExecution.getVariable(DefaultFields.PROCESS_FINDINGS.name()),
                 Finding.class
-            );
+        );
 
-        List<Target> newTargets = findings.stream()
+        Map<String, Set<String>> openPortsForTarget = new HashMap<>();
+
+        findings.stream()
                 .filter(finding -> finding.getCategory().equals("Open Port"))
-                .map(finding -> {
+                .forEach(finding -> {
                     String hostname = (String) finding.getAttribute(OpenPortAttributes.hostname);
                     String port = finding.getAttribute(OpenPortAttributes.port).toString();
 
-                    Target target = new Target();
-                    target.setLocation(hostname);
-                    target.appendOrUpdateAttribute("NIKTO_PORTS", port);
+                    if (openPortsForTarget.containsKey(hostname)) {
+                        openPortsForTarget.get(hostname).add(port);
+                    } else {
+                        Set<String> portSet = new HashSet<>();
+                        portSet.add(port);
+                        openPortsForTarget.put(hostname, portSet);
+                    }
 
-                    return target;
-                }).collect(Collectors.toList());
+                });
 
-        LOG.info("Created Targets out of Findings: " + newTargets);
+        List<Target> targets = ProcessVariableHelper.readListFromValue((String) delegateExecution.getVariable(DefaultFields.PROCESS_TARGETS.name()),
+                Target.class
+        ).stream()
+                .filter(target -> openPortsForTarget.containsKey(target.getLocation()))
+                .collect(Collectors.toList());
+
+        targets.forEach(target -> {
+            Set<String> portsToScanByNikto = this.getSanitizedPortSet(target);
+            Set<String> filteredPorts = this.filterIrrelevantPorts(portsToScanByNikto, openPortsForTarget.get(target.getLocation()));
+            target.appendOrUpdateAttribute("NIKTO_PORTS", String.join(",", filteredPorts));
+        });
+
+        targets.stream().filter(target -> !this.hasEmptyNiktoPortList(target));
+
+
+        LOG.info("Created Targets out of Findings: " + targets);
 
         delegateExecution.setVariable(DefaultFields.PROCESS_TARGETS.name(),
-                ProcessVariableHelper.generateObjectValue(newTargets)
+                ProcessVariableHelper.generateObjectValue(targets)
         );
+    }
+
+    private Set<String> filterIrrelevantPorts(Set<String> portsToScanByNikto, Set<String> openPorts) {
+        if (openPorts.equals(portsToScanByNikto))
+            return portsToScanByNikto;
+
+        Set<String> portSet = portsToScanByNikto.stream().filter(openPorts::contains).collect(Collectors.toSet());
+        return portSet;
+    }
+
+    private Set<String> getSanitizedPortSet(Target target) {
+        // Create a Set to ensure every port is only scanned once per host
+        Set<String> portsToScanByNikto = new HashSet<>();
+
+        // Transform Comma separated ports into an Array
+        String[] portArray = ((String) target.getAttributes().get("COMBINED_NMAP_NIKTO_PORTS")).split(",");
+
+        // Remove whitespaces before and after port
+        for (String port : portArray) {
+            port = port.trim();
+        }
+
+        // Move portArray into a Set to ensure every Port is only scanned once for each  host
+        Collections.addAll(portsToScanByNikto, portArray);
+        return portsToScanByNikto;
+    }
+
+    private boolean hasEmptyNiktoPortList(Target target) {
+        String niktoPortList = (String) target.getAttributes().get("NIKTO_PORTS");
+        return niktoPortList.isEmpty();
     }
 
 }

--- a/scb-scanprocesses/combined-nmap-nikto-process/src/main/java/io/securecodebox/scanprocess/listener/NmapToNiktoTransformListener.java
+++ b/scb-scanprocesses/combined-nmap-nikto-process/src/main/java/io/securecodebox/scanprocess/listener/NmapToNiktoTransformListener.java
@@ -14,6 +14,7 @@ import java.util.stream.Collectors;
 @Component
 public class NmapToNiktoTransformListener extends TransformFindingsToTargetsListener {
 
+    private final String PORT_DELIMITER = ",";
     private final String DEFAULT_COMBINED_NMAP_NIKTO_PORTS = "80, 443, 8080, 8443";
 
     public void notify(DelegateExecution delegateExecution) throws Exception {
@@ -48,14 +49,8 @@ public class NmapToNiktoTransformListener extends TransformFindingsToTargetsList
         // Create a Set to ensure every port is only scanned once per host
         Set<String> portsToScanByNikto = new HashSet<>();
 
-        String combinedNmapNiktoPortsAsString = (String) target.getAttributes().get("COMBINED_NMAP_NIKTO_PORTS");
-
-        //Use default ports if no ports are specified
-        if (combinedNmapNiktoPortsAsString.isEmpty())
-            combinedNmapNiktoPortsAsString = this.DEFAULT_COMBINED_NMAP_NIKTO_PORTS;
-
         // Transform Comma separated ports into an Array
-        String[] combinedNmapNiktoPortsAsArray = combinedNmapNiktoPortsAsString.split(",");
+        String[] combinedNmapNiktoPortsAsArray = this.getCombinedNmapNiktoPorts(target).split(this.PORT_DELIMITER);
 
         // Remove whitespaces before and after port and add to Collection
         for (String port : combinedNmapNiktoPortsAsArray) {
@@ -63,12 +58,18 @@ public class NmapToNiktoTransformListener extends TransformFindingsToTargetsList
         }
 
         // Move portArray into a Set to ensure every Port is only scanned once for each  host
-        return portsToScanByNikto.stream()
+        portsToScanByNikto = portsToScanByNikto.stream()
                 // remove empty entries
                 .filter(port -> !port.isEmpty())
                 // remove entries that have to long ports or letters or start with zero
                 .filter(port -> Pattern.matches("[1-9]+[0-9]{0,4}", port))
                 .collect(Collectors.toSet());
+
+        // Use default ports if not specified otherwise
+        if (portsToScanByNikto.isEmpty())
+            return this.getDefaultPorts();
+
+        return portsToScanByNikto;
     }
 
     private boolean hasEmptyNiktoPortList(Target target) {
@@ -107,7 +108,7 @@ public class NmapToNiktoTransformListener extends TransformFindingsToTargetsList
         targets.forEach(target -> {
             Set<String> portsToScanByNikto = this.getRelevantPorts(target);
             Set<String> filteredPorts = this.filterIrrelevantPorts(portsToScanByNikto, openPortsPerTarget.get(target.getLocation()));
-            target.appendOrUpdateAttribute("NIKTO_PORTS", String.join(", ", filteredPorts));
+            target.appendOrUpdateAttribute("NIKTO_PORTS", String.join(this.PORT_DELIMITER, filteredPorts));
         });
     }
 
@@ -129,5 +130,30 @@ public class NmapToNiktoTransformListener extends TransformFindingsToTargetsList
 
     private void startNitktoScan(Set<Target> targets, DelegateExecution delegateExecution) {
         delegateExecution.setVariable(DefaultFields.PROCESS_TARGETS.name(), ProcessVariableHelper.generateObjectValue(targets));
+    }
+
+    private String getCombinedNmapNiktoPorts(Target target) {
+        String combinedNmapNiktoPortsAsString = (String) target.getAttributes().get("COMBINED_NMAP_NIKTO_PORTS");
+
+        // Check if COMBINED_NMAP_NIKTO_PORTS are set at all
+        if (combinedNmapNiktoPortsAsString == null)
+            return this.DEFAULT_COMBINED_NMAP_NIKTO_PORTS;
+
+        //Use default ports if no ports are specified
+        if (combinedNmapNiktoPortsAsString.isEmpty())
+            return this.DEFAULT_COMBINED_NMAP_NIKTO_PORTS;
+
+        return combinedNmapNiktoPortsAsString;
+    }
+
+    private Set<String> getDefaultPorts() {
+        Set<String> portsToScanByNikto = new HashSet<>();
+        String[] combinedNmapNiktoPortsAsArray = this.DEFAULT_COMBINED_NMAP_NIKTO_PORTS.split(this.PORT_DELIMITER);
+
+        // Remove whitespaces before and after port and add to Collection
+        for (String port : combinedNmapNiktoPortsAsArray) {
+            portsToScanByNikto.add(port.trim());
+        }
+        return portsToScanByNikto;
     }
 }

--- a/scb-scanprocesses/combined-nmap-nikto-process/src/main/java/io/securecodebox/scanprocess/listener/NmapToNiktoTransformListener.java
+++ b/scb-scanprocesses/combined-nmap-nikto-process/src/main/java/io/securecodebox/scanprocess/listener/NmapToNiktoTransformListener.java
@@ -17,9 +17,9 @@ public class NmapToNiktoTransformListener extends TransformFindingsToTargetsList
     public void notify(DelegateExecution delegateExecution) throws Exception {
         List<Finding> findings = ProcessVariableHelper.readListFromValue((String) delegateExecution.getVariable(DefaultFields.PROCESS_FINDINGS.name()), Finding.class);
 
-        Map<String, Set<String>> openPortsPerTarget = this.findOpenPortsPerTarget(findings);
-
         List<Target> oldTargets = ProcessVariableHelper.readListFromValue((String) delegateExecution.getVariable(DefaultFields.PROCESS_TARGETS.name()), Target.class);
+
+        Map<String, Set<String>> openPortsPerTarget = this.findOpenPortsPerTarget(findings);
 
         Set<Target> targets = this.collectTargetsWithOpenPorts(oldTargets, openPortsPerTarget);
 

--- a/scb-scanprocesses/combined-nmap-nikto-process/src/main/java/io/securecodebox/scanprocess/listener/NmapToNiktoTransformListener.java
+++ b/scb-scanprocesses/combined-nmap-nikto-process/src/main/java/io/securecodebox/scanprocess/listener/NmapToNiktoTransformListener.java
@@ -15,7 +15,6 @@ import java.util.stream.Collectors;
 public class NmapToNiktoTransformListener extends TransformFindingsToTargetsListener {
 
     public void notify(DelegateExecution delegateExecution) throws Exception {
-
         List<Finding> findings = ProcessVariableHelper.readListFromValue((String) delegateExecution.getVariable(DefaultFields.PROCESS_FINDINGS.name()), Finding.class);
         List<Target> oldTargets = ProcessVariableHelper.readListFromValue((String) delegateExecution.getVariable(DefaultFields.PROCESS_TARGETS.name()), Target.class);
         Set<Target> newTargets = this.nmapToNiktoTransformAction(findings, oldTargets);

--- a/scb-scanprocesses/combined-nmap-nikto-process/src/main/java/io/securecodebox/scanprocess/listener/NmapToNiktoTransformListener.java
+++ b/scb-scanprocesses/combined-nmap-nikto-process/src/main/java/io/securecodebox/scanprocess/listener/NmapToNiktoTransformListener.java
@@ -36,7 +36,7 @@ public class NmapToNiktoTransformListener extends TransformFindingsToTargetsList
     private Set<String> filterIrrelevantPorts(Set<String> portsToScanByNikto, Set<Finding> openPorts) {
         Set<String> portSet = new HashSet<>();
         openPorts.forEach(finding -> {
-            String port = (String) finding.getAttribute(OpenPortAttributes.port);
+            String port = String.valueOf(finding.getAttribute(OpenPortAttributes.port));
             if (portsToScanByNikto.contains(port))
                 portSet.add(port);
         });

--- a/scb-scanprocesses/combined-nmap-nikto-process/src/main/java/io/securecodebox/scanprocess/listener/NmapToNiktoTransformListener.java
+++ b/scb-scanprocesses/combined-nmap-nikto-process/src/main/java/io/securecodebox/scanprocess/listener/NmapToNiktoTransformListener.java
@@ -16,8 +16,10 @@ public class NmapToNiktoTransformListener extends TransformFindingsToTargetsList
 
     private final String PORT_DELIMITER = ",";
     private final String DEFAULT_COMBINED_NMAP_NIKTO_PORTS = "80, 443, 8080, 8443";
+    protected static final String ATTRIBUTE_BLACKBOX = "BLACKBOX";
+    protected static  final String ATTRIBUTE_COMBINED_NMAP_NIKTO_PORTS = "COMBINED_NMAP_NIKTO_PORTS";
 
-    public void notify(DelegateExecution delegateExecution) throws Exception {
+    public void notify(DelegateExecution delegateExecution) {
         List<Finding> findings = ProcessVariableHelper.readListFromValue((String) delegateExecution.getVariable(DefaultFields.PROCESS_FINDINGS.name()), Finding.class);
         List<Target> oldTargets = ProcessVariableHelper.readListFromValue((String) delegateExecution.getVariable(DefaultFields.PROCESS_TARGETS.name()), Target.class);
         Set<Target> newTargets = this.nmapToNiktoTransformAction(findings, oldTargets);
@@ -29,7 +31,7 @@ public class NmapToNiktoTransformListener extends TransformFindingsToTargetsList
      *
      * @param portsToScanByNikto specified COMBINED_NMAP_NIKTO_PORTS
      * @param openPorts          Open ports found by nmap
-     * @return
+     * @return portSet
      */
     private Set<String> filterIrrelevantPorts(Set<String> portsToScanByNikto, Set<Finding> openPorts) {
         Set<String> portSet = new HashSet<>();
@@ -85,7 +87,6 @@ public class NmapToNiktoTransformListener extends TransformFindingsToTargetsList
                 .filter(finding -> finding.getCategory().equals("Open Port"))
                 .forEach(finding -> {
                     String hostname = (String) finding.getAttribute(OpenPortAttributes.hostname);
-                    String port = finding.getAttribute(OpenPortAttributes.port).toString();
 
                     if (openPortsPerTarget.containsKey(hostname)) {
                         openPortsPerTarget.get(hostname).add(finding);
@@ -144,7 +145,7 @@ public class NmapToNiktoTransformListener extends TransformFindingsToTargetsList
     }
 
     private String getCombinedNmapNiktoPorts(Target target) {
-        String combinedNmapNiktoPortsAsString = (String) target.getAttributes().get("COMBINED_NMAP_NIKTO_PORTS");
+        String combinedNmapNiktoPortsAsString = (String) target.getAttributes().get(ATTRIBUTE_COMBINED_NMAP_NIKTO_PORTS);
 
         // Check if COMBINED_NMAP_NIKTO_PORTS are set at all
         if (combinedNmapNiktoPortsAsString == null)
@@ -169,9 +170,9 @@ public class NmapToNiktoTransformListener extends TransformFindingsToTargetsList
     }
 
     private boolean isBlackBoxScan(Target target) {
-        if (!target.getAttributes().containsKey("blackbox"))
+        if (!target.getAttributes().containsKey(ATTRIBUTE_BLACKBOX))
             return false;
 
-        return ((String) target.getAttributes().get("blackbox")).toLowerCase().equals("true");
+        return target.getAttributes().get(ATTRIBUTE_BLACKBOX).toString().toLowerCase().equals("true");
     }
 }

--- a/scb-scanprocesses/combined-nmap-nikto-process/src/main/java/io/securecodebox/scanprocess/listener/NmapToNiktoTransformListener.java
+++ b/scb-scanprocesses/combined-nmap-nikto-process/src/main/java/io/securecodebox/scanprocess/listener/NmapToNiktoTransformListener.java
@@ -14,6 +14,8 @@ import java.util.stream.Collectors;
 @Component
 public class NmapToNiktoTransformListener extends TransformFindingsToTargetsListener {
 
+    private final String DEFAULT_COMBINED_NMAP_NIKTO_PORTS = "80, 443, 8080, 8443";
+
     public void notify(DelegateExecution delegateExecution) throws Exception {
         List<Finding> findings = ProcessVariableHelper.readListFromValue((String) delegateExecution.getVariable(DefaultFields.PROCESS_FINDINGS.name()), Finding.class);
         List<Target> oldTargets = ProcessVariableHelper.readListFromValue((String) delegateExecution.getVariable(DefaultFields.PROCESS_TARGETS.name()), Target.class);
@@ -46,11 +48,17 @@ public class NmapToNiktoTransformListener extends TransformFindingsToTargetsList
         // Create a Set to ensure every port is only scanned once per host
         Set<String> portsToScanByNikto = new HashSet<>();
 
+        String combinedNmapNiktoPortsAsString = (String) target.getAttributes().get("COMBINED_NMAP_NIKTO_PORTS");
+
+        //Use default ports if no ports are specified
+        if (combinedNmapNiktoPortsAsString.isEmpty())
+            combinedNmapNiktoPortsAsString = this.DEFAULT_COMBINED_NMAP_NIKTO_PORTS;
+
         // Transform Comma separated ports into an Array
-        String[] portArray = ((String) target.getAttributes().get("COMBINED_NMAP_NIKTO_PORTS")).split(",");
+        String[] combinedNmapNiktoPortsAsArray = combinedNmapNiktoPortsAsString.split(",");
 
         // Remove whitespaces before and after port and add to Collection
-        for (String port : portArray) {
+        for (String port : combinedNmapNiktoPortsAsArray) {
             portsToScanByNikto.add(port.trim());
         }
 

--- a/scb-scanprocesses/combined-nmap-nikto-process/src/main/java/io/securecodebox/scanprocess/listener/NmapToNiktoTransformListener.java
+++ b/scb-scanprocesses/combined-nmap-nikto-process/src/main/java/io/securecodebox/scanprocess/listener/NmapToNiktoTransformListener.java
@@ -173,6 +173,6 @@ public class NmapToNiktoTransformListener extends TransformFindingsToTargetsList
         if (!target.getAttributes().containsKey(ATTRIBUTE_BLACKBOX))
             return false;
 
-        return target.getAttributes().get(ATTRIBUTE_BLACKBOX).toString().toLowerCase().equals("true");
+        return target.getAttributes().get(ATTRIBUTE_BLACKBOX).toString().equalsIgnoreCase("true");
     }
 }

--- a/scb-scanprocesses/combined-nmap-nikto-process/src/main/java/io/securecodebox/scanprocess/listener/NmapToNiktoTransformListener.java
+++ b/scb-scanprocesses/combined-nmap-nikto-process/src/main/java/io/securecodebox/scanprocess/listener/NmapToNiktoTransformListener.java
@@ -17,12 +17,9 @@ public class NmapToNiktoTransformListener extends TransformFindingsToTargetsList
     public void notify(DelegateExecution delegateExecution) throws Exception {
 
         List<Finding> findings = ProcessVariableHelper.readListFromValue((String) delegateExecution.getVariable(DefaultFields.PROCESS_FINDINGS.name()), Finding.class);
-
         List<Target> oldTargets = ProcessVariableHelper.readListFromValue((String) delegateExecution.getVariable(DefaultFields.PROCESS_TARGETS.name()), Target.class);
-
         Set<Target> newTargets = this.nmapToNiktoTransformAction(findings, oldTargets);
-
-        delegateExecution.setVariable(DefaultFields.PROCESS_TARGETS.name(), ProcessVariableHelper.generateObjectValue(newTargets));
+        this.startNitktoScan(newTargets, delegateExecution);
     }
 
     /**
@@ -122,5 +119,9 @@ public class NmapToNiktoTransformListener extends TransformFindingsToTargetsList
 
         return targets;
 
+    }
+
+    private void startNitktoScan(Set<Target> targets, DelegateExecution delegateExecution) {
+        delegateExecution.setVariable(DefaultFields.PROCESS_TARGETS.name(), ProcessVariableHelper.generateObjectValue(targets));
     }
 }

--- a/scb-scanprocesses/combined-nmap-nikto-process/src/main/java/io/securecodebox/scanprocess/listener/NmapToNiktoTransformListener.java
+++ b/scb-scanprocesses/combined-nmap-nikto-process/src/main/java/io/securecodebox/scanprocess/listener/NmapToNiktoTransformListener.java
@@ -66,7 +66,8 @@ public class NmapToNiktoTransformListener extends TransformFindingsToTargetsList
                 // remove empty entries
                 .filter(port -> !port.isEmpty())
                 // remove entries that have to long ports or letters or start with zero
-                .filter(port -> Pattern.matches("[1-9]+[0-9]{0,4}", port))
+                // Regex from: https://www.regextester.com/104146
+                .filter(port -> Pattern.matches("^()([1-9]|[1-5]?[0-9]{2,4}|6[1-4][0-9]{3}|65[1-4][0-9]{2}|655[1-2][0-9]|6553[1-5])$", port))
                 .collect(Collectors.toSet());
 
         // Use default ports if not specified otherwise

--- a/scb-scanprocesses/combined-nmap-nikto-process/src/main/resources/forms/configure-nmap-nikto-target.html
+++ b/scb-scanprocesses/combined-nmap-nikto-process/src/main/resources/forms/configure-nmap-nikto-target.html
@@ -123,7 +123,7 @@
                         <input required class="form-control"
                                type="text"
                                placeholder="80,443,3000,8080,8443"
-                               ng-minlength="3"
+                               ng-minlength="2"
                                ng-maxlength="100"
                                ng-model="target.attributes.COMBINED_NMAP_NIKTO_PORTS"
                         />

--- a/scb-scanprocesses/combined-nmap-nikto-process/src/main/resources/forms/configure-nmap-nikto-target.html
+++ b/scb-scanprocesses/combined-nmap-nikto-process/src/main/resources/forms/configure-nmap-nikto-target.html
@@ -122,7 +122,7 @@
                         <label>Nikto Ports</label>
                         <input required class="form-control"
                                type="text"
-                               placeholder="80,443,3000,8080,8443"
+                               placeholder="e.g. 80,443,8080,8443"
                                ng-minlength="2"
                                ng-maxlength="100"
                                ng-model="target.attributes.COMBINED_NMAP_NIKTO_PORTS"

--- a/scb-scanprocesses/combined-nmap-nikto-process/src/main/resources/forms/configure-nmap-nikto-target.html
+++ b/scb-scanprocesses/combined-nmap-nikto-process/src/main/resources/forms/configure-nmap-nikto-target.html
@@ -36,7 +36,7 @@
                 location: camForm.variableManager.variableValue('DEFAULT_TARGET_LOCATION'),
                 attributes: {
                     COMBINED_NMAP_NIKTO_PORTS: '',
-                    blackbox: ''
+                    BLACKBOX: ''
                 }
             }];
 
@@ -133,7 +133,7 @@
                     </div>
                     <div class="col-xs-12">
                         <label>
-                            <input type="checkbox" ng-model="target.attributes.blackbox" class="ng-pristine ng-valid">
+                            <input type="checkbox" ng-model="target.attributes.BLACKBOX" class="ng-pristine ng-valid">
                             Scan all http(s) Services discovered by nmap (blackbox scan)
                         </label>
                     </div>

--- a/scb-scanprocesses/combined-nmap-nikto-process/src/main/resources/forms/configure-nmap-nikto-target.html
+++ b/scb-scanprocesses/combined-nmap-nikto-process/src/main/resources/forms/configure-nmap-nikto-target.html
@@ -33,7 +33,10 @@
 
             $scope.targetList = [{
                 name: camForm.variableManager.variableValue('DEFAULT_TARGET_NAME'),
-                location: camForm.variableManager.variableValue('DEFAULT_TARGET_LOCATION')
+                location: camForm.variableManager.variableValue('DEFAULT_TARGET_LOCATION'),
+                attributes: {
+                    COMBINED_NMAP_NIKTO_PORTS: ''
+                }
             }];
 
             $scope.attributeMapping = [];
@@ -114,6 +117,16 @@
                                 style="position: absolute; right: 15px; top: 0;">
                             <span class="glyphicon glyphicon-trash"></span>
                         </button>
+                    </div>
+                    <div class="col-xs-12">
+                        <label>Nikto Ports</label>
+                        <input required class="form-control"
+                               type="text"
+                               placeholder="80,443,3000,8080,8443"
+                               ng-minlength="3"
+                               ng-maxlength="100"
+                               ng-model="target.attributes.COMBINED_NMAP_NIKTO_PORTS"
+                        />
                     </div>
                 </div>
                 <button class="btn btn-primary" ng-click="addTarget()">Add Host</button>

--- a/scb-scanprocesses/combined-nmap-nikto-process/src/main/resources/forms/configure-nmap-nikto-target.html
+++ b/scb-scanprocesses/combined-nmap-nikto-process/src/main/resources/forms/configure-nmap-nikto-target.html
@@ -35,7 +35,8 @@
                 name: camForm.variableManager.variableValue('DEFAULT_TARGET_NAME'),
                 location: camForm.variableManager.variableValue('DEFAULT_TARGET_LOCATION'),
                 attributes: {
-                    COMBINED_NMAP_NIKTO_PORTS: ''
+                    COMBINED_NMAP_NIKTO_PORTS: '',
+                    blackbox: ''
                 }
             }];
 
@@ -80,6 +81,8 @@
             });
         });
 
+
+
     </script>
 
     <div class="row">
@@ -120,13 +123,19 @@
                     </div>
                     <div class="col-xs-12">
                         <label>Nikto Ports</label>
-                        <input required class="form-control"
+                        <input class="form-control"
                                type="text"
                                placeholder="e.g. 80,443,8080,8443"
                                ng-minlength="2"
                                ng-maxlength="100"
                                ng-model="target.attributes.COMBINED_NMAP_NIKTO_PORTS"
                         />
+                    </div>
+                    <div class="col-xs-12">
+                        <label>
+                            <input type="checkbox" ng-model="target.attributes.blackbox" class="ng-pristine ng-valid">
+                            Scan all http(s) Services discovered by nmap (blackbox scan)
+                        </label>
                     </div>
                 </div>
                 <button class="btn btn-primary" ng-click="addTarget()">Add Host</button>
@@ -146,7 +155,7 @@
                            ng-required="false"
                            ng-maxlength="50"
                            ng-model="context"
-                           name="context" />
+                           name="context"/>
                 </div>
             </div>
 

--- a/scb-scanprocesses/combined-nmap-nikto-process/src/test/java/io/securecodebox/scanprocess/listener/NmapToNiktoTransformListenerTest.java
+++ b/scb-scanprocesses/combined-nmap-nikto-process/src/test/java/io/securecodebox/scanprocess/listener/NmapToNiktoTransformListenerTest.java
@@ -82,4 +82,15 @@ public class NmapToNiktoTransformListenerTest {
         assertTrue(openPortsPerTarget.get(TARGET_HOST).contains("3000"), "should contain open port 3000");
     }
 
+    @Test
+    protected void shouldNotFindOpenPorts() {
+        Finding finding = new Finding();
+        finding.addAttribute(OpenPortAttributes.hostname, TARGET_HOST);
+        finding.setCategory("Version Issue");
+        finding.addAttribute(OpenPortAttributes.port, "3000");
+        List<Finding> findings = new LinkedList<>();
+        findings.add(finding);
+        Map<String, Set<String>> openPortsPerTarget = listener.findOpenPortsPerTarget(findings);
+        assertTrue(openPortsPerTarget.isEmpty());
+    }
 }

--- a/scb-scanprocesses/combined-nmap-nikto-process/src/test/java/io/securecodebox/scanprocess/listener/NmapToNiktoTransformListenerTest.java
+++ b/scb-scanprocesses/combined-nmap-nikto-process/src/test/java/io/securecodebox/scanprocess/listener/NmapToNiktoTransformListenerTest.java
@@ -157,8 +157,8 @@ public class NmapToNiktoTransformListenerTest {
         Target target = new Target();
         target.setName(TARGET_NAME);
         target.setLocation(TARGET_LOCATION);
-        target.appendOrUpdateAttribute("COMBINED_NMAP_NIKTO_PORTS", "3000");
-        target.appendOrUpdateAttribute("blackbox", "true");
+        target.appendOrUpdateAttribute(NmapToNiktoTransformListener.ATTRIBUTE_COMBINED_NMAP_NIKTO_PORTS, "3000");
+        target.appendOrUpdateAttribute(NmapToNiktoTransformListener.ATTRIBUTE_BLACKBOX, "true");
         oldTargets.add(target);
         this.transform();
         assertEquals("80", niktoPorts, "should be equal to 80 as result of blackbox test" );
@@ -171,8 +171,8 @@ public class NmapToNiktoTransformListenerTest {
         Target target = new Target();
         target.setLocation(TARGET_LOCATION);
         target.setName(TARGET_NAME);
-        target.appendOrUpdateAttribute("blackbox", "false");
-        target.appendOrUpdateAttribute("COMBINED_NMAP_NIKTO_PORTS", "3000");
+        target.appendOrUpdateAttribute(NmapToNiktoTransformListener.ATTRIBUTE_BLACKBOX, "false");
+        target.appendOrUpdateAttribute(NmapToNiktoTransformListener.ATTRIBUTE_COMBINED_NMAP_NIKTO_PORTS, "3000");
         oldTargets.add(target);
         this.transform();
         assertTrue(newTargets.isEmpty());
@@ -190,7 +190,7 @@ public class NmapToNiktoTransformListenerTest {
         Target target = new Target();
         target.setLocation(location);
         target.setName(name);
-        target.appendOrUpdateAttribute("COMBINED_NMAP_NIKTO_PORTS", combinedNmapNiktoPorts);
+        target.appendOrUpdateAttribute(NmapToNiktoTransformListener.ATTRIBUTE_COMBINED_NMAP_NIKTO_PORTS, combinedNmapNiktoPorts);
         return target;
     }
 

--- a/scb-scanprocesses/combined-nmap-nikto-process/src/test/java/io/securecodebox/scanprocess/listener/NmapToNiktoTransformListenerTest.java
+++ b/scb-scanprocesses/combined-nmap-nikto-process/src/test/java/io/securecodebox/scanprocess/listener/NmapToNiktoTransformListenerTest.java
@@ -149,6 +149,35 @@ public class NmapToNiktoTransformListenerTest {
         assertEquals("80", niktoPorts, "should be equal to 3000 as result of using default ports");
     }
 
+    @Test
+    protected void shouldPerformBlackBoxScan() {
+        Finding finding = createFinding(TARGET_LOCATION, "80", "Open Port");
+        finding.addAttribute(OpenPortAttributes.service, "http");
+        findings.add(finding);
+        Target target = new Target();
+        target.setName(TARGET_NAME);
+        target.setLocation(TARGET_LOCATION);
+        target.appendOrUpdateAttribute("COMBINED_NMAP_NIKTO_PORTS", "3000");
+        target.appendOrUpdateAttribute("blackbox", "true");
+        oldTargets.add(target);
+        this.transform();
+        assertEquals("80", niktoPorts, "should be equal to 80 as result of blackbox test" );
+    }
+
+    @Test
+    protected void shouldNotPerformBlackBoxScan() {
+        Finding finding = createFinding(TARGET_LOCATION, "80", "Open Port");
+        findings.add(finding);
+        Target target = new Target();
+        target.setLocation(TARGET_LOCATION);
+        target.setName(TARGET_NAME);
+        target.appendOrUpdateAttribute("blackbox", "false");
+        target.appendOrUpdateAttribute("COMBINED_NMAP_NIKTO_PORTS", "3000");
+        oldTargets.add(target);
+        this.transform();
+        assertTrue(newTargets.isEmpty());
+    }
+
     private Finding createFinding(String hostname, String port, String category) {
         Finding finding = new Finding();
         finding.addAttribute(OpenPortAttributes.hostname, hostname);

--- a/scb-scanprocesses/combined-nmap-nikto-process/src/test/java/io/securecodebox/scanprocess/listener/NmapToNiktoTransformListenerTest.java
+++ b/scb-scanprocesses/combined-nmap-nikto-process/src/test/java/io/securecodebox/scanprocess/listener/NmapToNiktoTransformListenerTest.java
@@ -13,7 +13,7 @@ public class NmapToNiktoTransformListenerTest {
 
     private static Set<String> portsToScanByNikto;
     private static NmapToNiktoTransformListener listener;
-    
+
     private final String TARGET_HOST = "test-host";
     private final String TARGET_LOCATION = "test-location";
 
@@ -67,10 +67,7 @@ public class NmapToNiktoTransformListenerTest {
 
     @Test
     protected void shouldFindOpenPort() {
-        Finding finding = new Finding();
-        finding.setCategory("Open Port");
-        finding.addAttribute(OpenPortAttributes.port, "3000");
-        finding.addAttribute(OpenPortAttributes.hostname, TARGET_HOST);
+        Finding finding = createFinding(TARGET_HOST, "3000", "Open Port");
         List<Finding> findings = new LinkedList<>();
         findings.add(finding);
         Map<String, Set<String>> openPortsPerTarget = listener.getOpenPortsPerTarget(findings);
@@ -79,10 +76,7 @@ public class NmapToNiktoTransformListenerTest {
 
     @Test
     protected void shouldNotFindOpenPorts() {
-        Finding finding = new Finding();
-        finding.addAttribute(OpenPortAttributes.hostname, TARGET_HOST);
-        finding.setCategory("Version Issue");
-        finding.addAttribute(OpenPortAttributes.port, "3000");
+        Finding finding = createFinding(TARGET_HOST, "3000", "Version Issue");
         List<Finding> findings = new LinkedList<>();
         findings.add(finding);
         Map<String, Set<String>> openPortsPerTarget = listener.getOpenPortsPerTarget(findings);
@@ -98,15 +92,8 @@ public class NmapToNiktoTransformListenerTest {
 
     @Test
     protected void shouldIgnoreDuplicateFindings() {
-        Finding finding = new Finding();
-        finding.addAttribute(OpenPortAttributes.hostname, TARGET_HOST);
-        finding.setCategory("Open Port");
-        finding.addAttribute(OpenPortAttributes.port, "3000");
-
-        Finding finding2 = new Finding();
-        finding2.addAttribute(OpenPortAttributes.hostname, TARGET_HOST);
-        finding2.setCategory("Open Port");
-        finding2.addAttribute(OpenPortAttributes.port, "3000");
+        Finding finding = createFinding(TARGET_HOST, "3000", "Open Port");
+        Finding finding2 = createFinding(TARGET_HOST, "3000", "Open Port");
 
         List<Finding> findings = new LinkedList<>();
 
@@ -126,10 +113,7 @@ public class NmapToNiktoTransformListenerTest {
 
     @Test
     protected void shouldTransformTargetsToEmptyTargetList() {
-        Finding finding = new Finding();
-        finding.addAttribute(OpenPortAttributes.hostname, TARGET_HOST);
-        finding.addAttribute(OpenPortAttributes.port, "3000");
-        finding.setCategory("Open Port");
+        Finding finding = createFinding(TARGET_HOST, "3000", "Open Port");
 
         List<Finding> findings = new LinkedList<>();
         findings.add(finding);
@@ -141,4 +125,11 @@ public class NmapToNiktoTransformListenerTest {
         assertTrue(newTargets.isEmpty());
     }
 
+    private Finding createFinding(String hostname, String port, String category) {
+        Finding finding = new Finding();
+        finding.addAttribute(OpenPortAttributes.hostname, hostname);
+        finding.addAttribute(OpenPortAttributes.port, port);
+        finding.setCategory(category);
+        return finding;
+    }
 }

--- a/scb-scanprocesses/combined-nmap-nikto-process/src/test/java/io/securecodebox/scanprocess/listener/NmapToNiktoTransformListenerTest.java
+++ b/scb-scanprocesses/combined-nmap-nikto-process/src/test/java/io/securecodebox/scanprocess/listener/NmapToNiktoTransformListenerTest.java
@@ -13,14 +13,13 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class NmapToNiktoTransformListenerTest {
 
-    private static Set<String> portsToScanByNikto;
     private static NmapToNiktoTransformListener listener;
 
     private final String TARGET_NAME = "test-host";
     private final String TARGET_LOCATION = "test-location";
 
     @BeforeAll
-    private static void setUp() {
+    protected static void setUp() {
         listener = new NmapToNiktoTransformListener();
     }
 

--- a/scb-scanprocesses/combined-nmap-nikto-process/src/test/java/io/securecodebox/scanprocess/listener/NmapToNiktoTransformListenerTest.java
+++ b/scb-scanprocesses/combined-nmap-nikto-process/src/test/java/io/securecodebox/scanprocess/listener/NmapToNiktoTransformListenerTest.java
@@ -136,6 +136,17 @@ public class NmapToNiktoTransformListenerTest {
         assertTrue(newTargets.isEmpty());
     }
 
+    @Test
+    protected void shouldUseDefaultPorts() {
+        Finding finding = createFinding(TARGET_LOCATION, "80", "Open Port");
+        findings.add(finding);
+        Target target = createTarget(TARGET_NAME, TARGET_LOCATION, "");
+        oldTargets.add(target);
+        this.transform();
+        assertEquals(1, newTargets.size(), "should have exactly one target");
+        assertTrue(niktoPorts.equals("80"), "should be equal to 3000 as result of using default ports");
+    }
+
     private Finding createFinding(String hostname, String port, String category) {
         Finding finding = new Finding();
         finding.addAttribute(OpenPortAttributes.hostname, hostname);

--- a/scb-scanprocesses/combined-nmap-nikto-process/src/test/java/io/securecodebox/scanprocess/listener/NmapToNiktoTransformListenerTest.java
+++ b/scb-scanprocesses/combined-nmap-nikto-process/src/test/java/io/securecodebox/scanprocess/listener/NmapToNiktoTransformListenerTest.java
@@ -53,12 +53,10 @@ public class NmapToNiktoTransformListenerTest {
         findings.add(finding);
         findings.add(finding2);
         Set<Target> newTargets = listener.nmapToNiktoTransformAction(findings, oldTargets);
-
-        assertEquals(1, newTargets.size());
-        List<String> nmapPorts = new LinkedList<>();
-        newTargets.forEach(target1 -> nmapPorts.add((String) target.getAttributes().get("NIKTO_PORTS")));
-
-        assertEquals("3000, 80", nmapPorts.get(0), "should contain 3000 and 80 as Ports for Nikto");
+        assertEquals(1, newTargets.size(), "should create only one Target");
+        String niktoPorts = (String) newTargets.iterator().next().getAttributes().get("NIKTO_PORTS");
+        assertTrue(niktoPorts.contains("80" ), "should contain port 80");
+        assertTrue(niktoPorts.contains("3000"), "should contain port 3000");
     }
 
     @Test
@@ -67,7 +65,7 @@ public class NmapToNiktoTransformListenerTest {
         Finding finding1 = createFinding(TARGET_LOCATION, "80", "Open Port");
         Finding finding2 = createFinding(TARGET_LOCATION, "443", "Open Port");
         Finding finding3 = createFinding(TARGET_LOCATION, "3000", "Open Port");
-        Finding finding4 = createFinding(TARGET_LOCATION, "8080", "OpenPort");
+        Finding finding4 = createFinding(TARGET_LOCATION, "8080", "Open Port");
         Finding finding5 = createFinding(TARGET_LOCATION, "8443", "Open Port");
         List<Target> oldTargets = new LinkedList<>();
         List<Finding> findings = new LinkedList<>();
@@ -79,13 +77,13 @@ public class NmapToNiktoTransformListenerTest {
         findings.add(finding5);
 
         Set<Target> newTargets = listener.nmapToNiktoTransformAction(findings, oldTargets);
-        assertEquals(1, newTargets.size());
+        assertEquals(1, newTargets.size(), "should create only one target");
         String niktoPorts = (String) newTargets.iterator().next().getAttributes().get("NIKTO_PORTS");
-        assertTrue(niktoPorts.contains("80"));
-        assertTrue(niktoPorts.contains("443"));
-        assertTrue(niktoPorts.contains("3000"));
-        assertTrue(niktoPorts.contains("8080"));
-        assertTrue(niktoPorts.contains("8443"));
+        assertTrue(niktoPorts.contains("80"), "should contain Port 80");
+        assertTrue(niktoPorts.contains("443"),  "should contain Port 443");
+        assertTrue(niktoPorts.contains("3000"), "should contain port 3000");
+        assertTrue(niktoPorts.contains("8080"), "should contain port 8080");
+        assertTrue(niktoPorts.contains("8443"), "should contain port 8443");
     }
 
     @Test

--- a/scb-scanprocesses/combined-nmap-nikto-process/src/test/java/io/securecodebox/scanprocess/listener/NmapToNiktoTransformListenerTest.java
+++ b/scb-scanprocesses/combined-nmap-nikto-process/src/test/java/io/securecodebox/scanprocess/listener/NmapToNiktoTransformListenerTest.java
@@ -1,0 +1,64 @@
+package io.securecodebox.scanprocess.listener;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static junit.framework.TestCase.*;
+
+class NmapToNiktoTransformListenerTest {
+
+    private static Set<String> portsToScanByNikto;
+    private static NmapToNiktoTransformListener listener;
+    private static Set<String> openPorts;
+
+    @BeforeAll
+    private static void setUp() {
+        portsToScanByNikto = new HashSet<>();
+        portsToScanByNikto.add("80");
+        portsToScanByNikto.add("443");
+        portsToScanByNikto.add("3000");
+        portsToScanByNikto.add("8080");
+        portsToScanByNikto.add("8443");
+
+        listener = new NmapToNiktoTransformListener();
+        openPorts = new HashSet<>();
+    }
+
+    @AfterEach
+    private void clearOpenPorts() {
+        openPorts.clear();
+    }
+
+    @Test
+    protected void relevantPortsShouldBeEqualToOpenPorts() {
+        Set<String> openPorts = new HashSet<>();
+        openPorts.add("80");
+        openPorts.add("443");
+
+        assertTrue("relevant Ports are equal to open ports", listener.filterIrrelevantPorts(portsToScanByNikto, openPorts).equals(openPorts));
+    }
+
+    @Test
+    protected void relevantPortsShouldBeEmpty() {
+        openPorts.add("999999");
+        assertTrue("relevant ports are empty", listener.filterIrrelevantPorts(portsToScanByNikto, openPorts).isEmpty());
+    }
+
+    @Test
+    protected void relevantPortsShouldBeIntersection() {
+        openPorts.add("80");
+        openPorts.add("3000");
+        openPorts.add("9999");
+
+        Set<String> intersection = new HashSet<>();
+        intersection.add("80");
+        intersection.add("3000");
+
+        assertEquals("intersection should be equal to relevant ports", intersection, listener.filterIrrelevantPorts(portsToScanByNikto, openPorts));
+    }
+
+}

--- a/scb-scanprocesses/combined-nmap-nikto-process/src/test/java/io/securecodebox/scanprocess/listener/NmapToNiktoTransformListenerTest.java
+++ b/scb-scanprocesses/combined-nmap-nikto-process/src/test/java/io/securecodebox/scanprocess/listener/NmapToNiktoTransformListenerTest.java
@@ -5,12 +5,9 @@ import io.securecodebox.model.findings.Finding;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-
 import java.util.*;
-
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-
 public class NmapToNiktoTransformListenerTest {
 
     private static Set<String> portsToScanByNikto;
@@ -41,7 +38,7 @@ public class NmapToNiktoTransformListenerTest {
         Set<String> openPorts = new HashSet<>();
         openPorts.add("80");
         openPorts.add("443");
-        assertTrue(listener.filterIrrelevantPorts(portsToScanByNikto, openPorts).equals(openPorts), "relevant Ports are equal to open ports");
+        assertEquals(listener.filterIrrelevantPorts(portsToScanByNikto, openPorts), openPorts, "relevant Ports are equal to open ports");
     }
 
     @Test

--- a/scb-scanprocesses/combined-nmap-nikto-process/src/test/java/io/securecodebox/scanprocess/listener/NmapToNiktoTransformListenerTest.java
+++ b/scb-scanprocesses/combined-nmap-nikto-process/src/test/java/io/securecodebox/scanprocess/listener/NmapToNiktoTransformListenerTest.java
@@ -9,7 +9,9 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class NmapToNiktoTransformListenerTest {
 
@@ -144,7 +146,7 @@ public class NmapToNiktoTransformListenerTest {
         oldTargets.add(target);
         this.transform();
         assertEquals(1, newTargets.size(), "should have exactly one target");
-        assertTrue(niktoPorts.equals("80"), "should be equal to 3000 as result of using default ports");
+        assertEquals("80", niktoPorts, "should be equal to 3000 as result of using default ports");
     }
 
     private Finding createFinding(String hostname, String port, String category) {

--- a/scb-scanprocesses/combined-nmap-nikto-process/src/test/java/io/securecodebox/scanprocess/listener/NmapToNiktoTransformListenerTest.java
+++ b/scb-scanprocesses/combined-nmap-nikto-process/src/test/java/io/securecodebox/scanprocess/listener/NmapToNiktoTransformListenerTest.java
@@ -5,9 +5,12 @@ import io.securecodebox.model.findings.Finding;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+
 import java.util.*;
+
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+
 public class NmapToNiktoTransformListenerTest {
 
     private static Set<String> portsToScanByNikto;


### PR DESCRIPTION
Adding JUnit 5
I was refactoring the TransformListener to use a List of Ports that need to be scanned by nikto if open.
I changed the input form for this scan to make it possible to specify relevant ports for each target
If no Ports a specified the Listener will fallback to 80, 443, 8080 and 8443
I also added an option to blackbox scan all HTTP(s) services found by nmap